### PR TITLE
Enable Static IPs for HA deployments

### DIFF
--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -159,8 +159,8 @@
       "dbnodes": [
         {
           "name": "",
-          "admin_nic_ip": "",
-          "db_nic_ip": "",
+          "admin_nic_ips": [],
+          "db_nic_ips": [],
           "role": ""
         }
       ]

--- a/deploy/v2/terraform/modules/hdb_node/variables_local.tf
+++ b/deploy/v2/terraform/modules/hdb_node/variables_local.tf
@@ -41,8 +41,8 @@ locals {
         for dbnode in database.dbnodes : {
           platform       = database.platform,
           name           = "${dbnode.name}-0",
-          admin_nic_ip   = lookup(dbnode, "admin_nic_ip", false),
-          db_nic_ip      = lookup(dbnode, "db_nic_ip", false),
+          admin_nic_ip   = length(lookup(dbnode, "admin_nic_ips", [])) >= 1 ? lookup(dbnode, "admin_nic_ips", [])[0] : false,
+          db_nic_ip      = length(lookup(dbnode, "db_nic_ips", [])) >= 1 ? lookup(dbnode, "db_nic_ips", [])[0] : false,
           size           = database.size,
           os             = database.os,
           authentication = database.authentication
@@ -55,8 +55,8 @@ locals {
         for dbnode in database.dbnodes : {
           platform       = database.platform,
           name           = "${dbnode.name}-1",
-          admin_nic_ip   = lookup(dbnode, "admin_nic_ip", false),
-          db_nic_ip      = lookup(dbnode, "db_nic_ip", false),
+          admin_nic_ip   = length(lookup(dbnode, "admin_nic_ips", [])) >= 2 ? lookup(dbnode, "admin_nic_ips", [])[1] : false,
+          db_nic_ip      = length(lookup(dbnode, "db_nic_ips", [])) >= 2 ? lookup(dbnode, "db_nic_ips", [])[1] : false,
           size           = database.size,
           os             = database.os,
           authentication = database.authentication


### PR DESCRIPTION
## Problem

See [Azure/sap-hana#356](https://github.com/Azure/sap-hana/issues/356)

## Description

Updates the example `deploy/v2/input.json` to have lists for  `admin_nic_ips` and `db_nic_ips` instead of strings for a single `admin_nic_ip` and `db_nic_ip`.

The `local.dbnodes` variable munging in `deploy/v2/terraform/modules/hdb_node/variables-local.tf` has been updated to use the first IP in a list for the `-0` node, and the second for the `-1` node.

Note: No changes to the `hdb_node` main Terraform are required as the variable munging extracts only one IP per `dbnode`, as is currently being used. `false` is returned if no IP is available.

## Pre-Requisites

None

## Commitment to Test

- Testing takes 5 minutes
- Reviewing 2 files

## Test Instructions/Acceptance Criteria

1. Review the change to the [blank `input.json` template](https://github.com/Centiq/sap-hana/pull/16/files#diff-8dfe51c2bf2c1da29f7ec0982ed22827R162-R163)
   - [x] Key names and default values updated
1. Review the [not-necessarily HA changes](https://github.com/Centiq/sap-hana/pull/16/files#diff-681009318dcfcd7367ecd293fb4002fcR44-R45)
   - [x] First value is used if provided
   - [x] `false` is used if no values available
   - [x] Key name on the resulting object is singular and matches existing code
1. Review the [HA changes](https://github.com/Centiq/sap-hana/pull/16/files#diff-681009318dcfcd7367ecd293fb4002fcR58-R59)
   - [x] Second value is used if provided
   - [x] `false` is used if one or no values available
   - [x] Key name on the resulting object is singular and matches existing code
1. Check existing sequential IP address allocation has not been changed, run the Terraform plan command, selecting the IP allocations:\
   `util/terraform_v2.sh plan clustered_hana | grep -A 24 resource.*nics-dbnodes |grep -A3 -- -nic-ip`
   - [x] The `hdb1-0-admin-nic-ip` IP is `10.1.1.4`
   - [x] The `hdb1-1-admin-nic-ip` IP is `10.1.1.5`
   - [x] The `hdb1-0-db-nic-ip` IP  is `10.1.2.4`
   - [x] The `hdb1-1-db-nic-ip` IP is `10.1.2.5`
1. Update `dbnodes` entry in the `deploy/v2/template_samples/clustered_hana.json` template to contain some IPs:
   ```
         "dbnodes": [
           {
             "name": "hdb1",
             "role": "worker",
             "admin_nic_ips": [
               "10.1.1.20",
               "10.1.1.30"
             ],
             "db_nic_ips": [
               "10.1.2.40",
               "10.1.2.50"
             ]
           }
         ]
   ```
1. Run the Terraform plan command, selecting the IP allocations:\
   `util/terraform_v2.sh plan clustered_hana | grep -A 24 resource.*nics-dbnodes |grep -A3 -- -nic-ip`
   - [x] The `hdb1-0-admin-nic-ip` IP matches the first IP in the `admin_nic_ips` list
   - [x] The `hdb1-1-admin-nic-ip` IP matches the second IP in the `admin_nic_ips` list
   - [x] The `hdb1-0-db-nic-ip` IP matches the first IP in the `db_nic_ips` list
   - [x] The `hdb1-1-db-nic-ip` IP matches the second IP in the `db_nic_ips` list