### PR TITLE
Add the subscription id and tenant id to the output.json file for use by Ansible

### DIFF
--- a/deploy/v2/terraform/modules/output_files/main.tf
+++ b/deploy/v2/terraform/modules/output_files/main.tf
@@ -2,9 +2,17 @@
 # OUTPUT Files
 ##################################################################################################################
 
+# Get the Azure Target Subscription and Tenant IDs
+data "azurerm_client_config" "target" {
+}
+
 # Generates the output JSON with IP address and disk details
 resource "local_file" "output-json" {
   content = jsonencode({
+    "azure_config" = {
+      subscription_id = data.azurerm_client_config.target.subscription_id
+      tenant_id       = data.azurerm_client_config.target.tenant_id
+    },
     "infrastructure" = var.infrastructure,
     "jumpboxes" = {
       "windows" = [for jumpbox-windows in var.jumpboxes.windows : {


### PR DESCRIPTION
## Problem

As part of https://github.com/Azure/sap-hana/issues/338 and the future RHEL work, the Subscription and Tenant IDs are required for the STONITH configurations.

## Description

This PR uses the `azurerm_client_config` data provider to retrieve the above information and passes it into the `output.json` for use by Ansible.

## Pre-Requisites

None

## Commitment to Test

- Testing takes 10 minutes
- Reviewing 1 file

## Test Instructions/Acceptance Criteria

1. Ensure your working directory is clean:\
   `util/terraform_v2.sh clean`
   `y`
1. Initialise the terraform modules:\
   `util/terraform_v2.sh init`
1. Update the resource group in the `rti_only` template (make sure this is personalised/not going to conflict with any other resources), e.g.:\
   `util/set_resource_group.sh "pc-tf-test-rg" "rti_only"`
1. Build the infrastructure:\
   `util/terraform_v2.sh apply rti_only`
1. Note the `id` and `tenantId` values for the AZ Account information:\
   `az account show`
1. Using the output from the above, SSH to the RTI instance:\
   `ssh azureadm@<IP_ADDRESS>`
1. Check the `output.json` file for the azure configuration:\
   `cat output.json | |python -m json.tool | grep -A3 azure_config`
   - [x] The `subscription_id` value matches the above noted `id` value
   - [x] The `tenant_id` value matches the above noted `tenantId` value

## Post-Testing

:hand: Make sure you delete the resource group created for this test after completion.