### PR TITLE
Backlog items use synchronize

### DIFF
--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -3,8 +3,8 @@
 - name: Ensure key files are in place
   # If HSR is already enabled, we don't need to do this
   when: not hana_system_replication_enabled
-  become_user: "{{ sid_admin_user }}"
   block:
+
     - name: Ensure the Primary node SSFS files are placed on the Secondary node
       when: ansible_hostname != hana_database.nodes[0].dbname
       block:
@@ -45,16 +45,16 @@
 
         - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file is placed on the Secondary node
           synchronize:
-            delegate_to: "{{ hana_database.nodes[1].dbname }}"
-            archive: true
-            mode: pull
-            src: "{{ hana_database.nodes[0].dbname }}:{{ path_ssfs_dat }}"
+            src: "{{ hana_database.nodes[0].ip_admin_nic }}:{{ path_ssfs_dat }}"
             dest: "{{ path_ssfs_dat }}"
+            mode: pull
+            archive: true
+          delegate_to: "{{ hana_database.nodes[1].ip_admin_nic }}"
 
         - name: Ensure the Primary node SSFS_{{ sid | upper }}.KEY file is placed on the Secondary node
           synchronize:
-            delegate_to: "{{ hana_database.nodes[1].dbname }}"
-            archive: true
-            mode: pull
-            src: "{{ hana_database.nodes[0].dbname }}:{{ path_ssfs_key }}"
+            src: "{{ hana_database.nodes[0].ip_admin_nic }}:{{ path_ssfs_key }}"
             dest: "{{ path_ssfs_key }}"
+            mode: pull
+            archive: true
+          delegate_to: "{{ hana_database.nodes[1].ip_admin_nic }}"

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -5,56 +5,63 @@
   when: not hana_system_replication_enabled
   block:
 
-    - name: Ensure the Primary node SSFS files are placed on the Secondary node
+    - name: Ensure the secondary node SSFS files are backed up and removed
       when: ansible_hostname != hana_database.nodes[0].dbname
       block:
 
-        - name: Check SSFS_{{ sid | upper }}.DAT backup file exists on the Secondary node
+        - name: Check SSFS_{{ sid | upper }}.DAT backup file exists on the secondary node
           stat:
             path: "{{ path_ssfs_dat }}.bak"
           register: dat_backup_result
 
-        - name: Ensure SSFS_{{ sid | upper }}.DAT file is backed up on the Secondary node
+        - name: Ensure SSFS_{{ sid | upper }}.DAT file is backed up on the secondary node
           file:
             src: "{{ path_ssfs_dat }}"
             path: "{{ path_ssfs_dat }}.bak"
             state: hard
           when: dat_backup_result.stat.exists == false
 
-        - name: Check SSFS_{{ sid | upper }}.KEY backup file exists on the Secondary node
+        - name: Check SSFS_{{ sid | upper }}.KEY backup file exists on the secondary node
           stat:
             path: "{{ path_ssfs_key }}.bak"
           register: key_backup_result
 
-        - name: Ensure SSFS_{{ sid | upper }}.KEY file is backed up on the Secondary node
+        - name: Ensure SSFS_{{ sid | upper }}.KEY file is backed up on the secondary node
           file:
             src: "{{ path_ssfs_key }}"
             path: "{{ path_ssfs_key }}.bak"
             state: hard
           when: key_backup_result.stat.exists == false
 
-        - name: Ensure original SSFS_{{ sid | upper }}.DAT file is removed on the Secondary node
+        - name: Ensure original SSFS_{{ sid | upper }}.DAT file is removed on the secondary node
           file:
             path: "{{ path_ssfs_dat }}"
             state: absent
 
-        - name: Ensure original SSFS_{{ sid | upper }}.KEY file is removed on the Secondary node
+        - name: Ensure original SSFS_{{ sid | upper }}.KEY file is removed on the secondary node
           file:
             path: "{{ path_ssfs_key }}"
             state: absent
 
-        - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file is placed on the Secondary node
-          synchronize:
-            src: "{{ hana_database.nodes[0].ip_admin_nic }}:{{ path_ssfs_dat }}"
-            dest: "{{ path_ssfs_dat }}"
-            mode: pull
-            archive: true
-          delegate_to: "{{ hana_database.nodes[1].ip_admin_nic }}"
+    - name: Ensure the primary node SSFS files are placed on the secondary node
+      # become_user: "{{ ansible_user }}"
+      when: ansible_hostname == hana_database.nodes[1].dbname
+      block:
 
-        - name: Ensure the Primary node SSFS_{{ sid | upper }}.KEY file is placed on the Secondary node
+        - name: Ensure the primary node SSFS_{{ sid | upper }}.DAT file is placed on the secondary node
           synchronize:
-            src: "{{ hana_database.nodes[0].ip_admin_nic }}:{{ path_ssfs_key }}"
-            dest: "{{ path_ssfs_key }}"
-            mode: pull
+            set_remote_user: false
+            src: "{{ path_ssfs_dat }}"
+            dest: "{{ path_ssfs_dat }}"
+            mode: push
             archive: true
-          delegate_to: "{{ hana_database.nodes[1].ip_admin_nic }}"
+          delegate_to: "{{ hana_database.nodes[0].ip_admin_nic }}"
+
+        - name: Ensure the primary node SSFS_{{ sid | upper }}.KEY file is placed on the secondary node
+          synchronize:
+            set_remote_user: false
+            src: "{{ path_ssfs_key }}"
+            dest: "{{ path_ssfs_key }}"
+            mode: push
+            archive: true
+          delegate_to: "{{ hana_database.nodes[0].ip_admin_nic }}"

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -44,7 +44,6 @@
             state: absent
 
     - name: Ensure the primary node SSFS files are placed on the secondary node
-      # become_user: "{{ ansible_user }}"
       when: ansible_hostname == hana_database.nodes[1].dbname
       block:
 

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -5,22 +5,6 @@
   when: not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   block:
-    - name: Ensure the Primary node SSFS files are present on the local host
-      when: ansible_hostname == hana_database.nodes[0].dbname
-      block:
-
-        - name: Ensure there is a local copy of Primary node SSFS_{{ sid | upper }}.DAT file
-          fetch:
-            src: "{{ path_ssfs_dat }}"
-            dest: "{{ tmp_ssfs_dat }}"
-            flat: yes
-
-        - name: Ensure there is a local copy of Primary node SSFS_{{ sid | upper }}.KEY file
-          fetch:
-            src: "{{ path_ssfs_key }}"
-            dest: "{{ tmp_ssfs_key }}"
-            flat: yes
-
     - name: Ensure the Primary node SSFS files are placed on the Secondary node
       when: ansible_hostname != hana_database.nodes[0].dbname
       block:
@@ -60,19 +44,17 @@
             state: absent
 
         - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file is placed on the Secondary node
-          copy:
-            src: "{{ tmp_ssfs_dat }}"
+          synchronize:
+            delegate_to: "{{ hana_database.nodes[1].dbname }}"
+            archive: true
+            mode: pull
+            src: "{{ hana_database.nodes[0].dbname }}:{{ path_ssfs_dat }}"
             dest: "{{ path_ssfs_dat }}"
-            owner: "{{ sid_admin_user }}"
-            group: "{{ hana_group }}"
-            # the permissions on the .DAT file are different to those on the .KEY file.
-            mode: 0644
 
         - name: Ensure the Primary node SSFS_{{ sid | upper }}.KEY file is placed on the Secondary node
-          copy:
-            src: "{{ tmp_ssfs_key }}"
+          synchronize:
+            delegate_to: "{{ hana_database.nodes[1].dbname }}"
+            archive: true
+            mode: pull
+            src: "{{ hana_database.nodes[0].dbname }}:{{ path_ssfs_key }}"
             dest: "{{ path_ssfs_key }}"
-            owner: "{{ sid_admin_user }}"
-            group: "{{ hana_group }}"
-            # the permissions on the .DAT file are different to those on the .KEY file.
-            mode: 0640

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - import_tasks: pre_checks.yml
+- import_tasks: set_trust_relationship.yml
 - import_tasks: copy_ssfs_keys.yml
 - import_tasks: create_hana_backup.yml
 - import_tasks: provision_hana_replication.yml

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -3,20 +3,53 @@
 - name: Ensure ssh keys on both nodes
   become: "{{ sid_admin_user }}"
   block:
-    - name: Check for existence of id_rsa_trust file
+    - name: Check for existence of id_rsa file
       file:
-        path: ~/.ssh/id_rsa_trust
+        path: ~/.ssh/id_rsa
         state: file
       check_mode: true
-      register: id_rsa_trust_file_status
+      register: id_rsa_file_status
 
-    - name: Check for existence of id_rsa_trust.pub file
+    - name: Check for existence of id_rsa.pub file
       file:
-        path: ~/.ssh/id_rsa_trust.pub
+        path: ~/.ssh/id_rsa.pub
         state: file
       check_mode: true
-      register: id_rsa_trust_file_pub_status
+      register: id_rsa_file_pub_status
 
     - name: Ensure key pair exists
+      when: id_rsa_file_status.failed and id_rsa_file_pub_status.failed
       shell: >
-        ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa_trust -q -N ""
+        ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa -q -N ""
+
+    - name: Ensure the Public SSH key is stored in a variable
+      shell: cat /root/.ssh/id_rsa.pub
+      register: cluster_public_ssh_key
+
+    - name: Ensure the Primary Node public key is on the Secondary node
+      when: ansible_hostname == hana_database.nodes[1].dbname
+      authorized_key:
+        user: root
+        key: "{{ hostvars[hana_database.nodes[0]].cluster_public_ssh_key.stdout }}"
+
+    - name: Ensure the Secondary Node public key is on the Primary node
+      when: ansible_hostname == hana_database.nodes[0].dbname
+      authorized_key:
+        user: root
+        key: "{{ hostvars[hana_database.nodes[1]].cluster_public_ssh_key.stdout }}"
+
+    - name: Ensure trust relationship is working from primary to secondary
+      when: ansible_hostname == hana_database.nodes[0].dbname
+      shell: >
+        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[1]].ansible_default_ipv4.address] }} hostname
+      register: primary_to_secondary_ssh_result
+      changed_when: false
+      failed_when: primary_to_secondary_ssh_result != hana_database.nodes[1].dbname
+
+    - name: Ensure trust relationship is working from secondary to primary
+      when: ansible_hostname == hana_database.nodes[1].dbname
+      shell: >
+        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[0]].ansible_default_ipv4.address] }} hostname
+      register: secondary_to_primary_ssh_result
+      changed_when: false
+      failed_when: primary_to_secondary_ssh_result != hana_database.nodes[0].dbname

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -1,7 +1,6 @@
 ---
 
 - name: Ensure ssh keys on both nodes
-  # become_user: "{{ ansible_user }}"
   block:
     - name: Check for existence of id_rsa file
       stat:

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -23,6 +23,7 @@
     - name: Ensure the Public SSH key is stored in a variable
       shell: cat ~/.ssh/id_rsa.pub
       register: public_ssh_key
+      changed_when: false
 
     - name: Ensure the primary node public key is on the secondary node
       when: ansible_hostname == hana_database.nodes[1].dbname

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure ssh keys on both nodes
-  become_user: "{{ sid_admin_user }}"
+  # become_user: "{{ ansible_user }}"
   block:
     - name: Check for existence of id_rsa file
       stat:
@@ -28,13 +28,13 @@
     - name: Ensure the primary node public key is on the secondary node
       when: ansible_hostname == hana_database.nodes[1].dbname
       authorized_key:
-        user: "{{ sid_admin_user }}"
+        user: "root"
         key: "{{ hostvars[hana_database.nodes[0].ip_admin_nic].public_ssh_key.stdout }}"
 
     - name: Ensure the secondary node public key is on the primary node
       when: ansible_hostname == hana_database.nodes[0].dbname
       authorized_key:
-        user: "{{ sid_admin_user }}"
+        user: "root"
         key: "{{ hostvars[hana_database.nodes[1].ip_admin_nic].public_ssh_key.stdout }}"
 
     - name: Ensure trust relationship is working from primary to secondary

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Ensure ssh keys on both nodes
+  become: "{{ sid_admin_user }}"
+  block:
+    - name: Check for existence of id_rsa_trust file
+      file:
+        path: ~/.ssh/id_rsa_trust
+        state: file
+      check_mode: true
+      register: id_rsa_trust_file_status
+
+    - name: Check for existence of id_rsa_trust.pub file
+      file:
+        path: ~/.ssh/id_rsa_trust.pub
+        state: file
+      check_mode: true
+      register: id_rsa_trust_file_pub_status
+
+    - name: Ensure key pair exists
+      shell: >
+        ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa_trust -q -N ""

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -41,7 +41,7 @@
     - name: Ensure trust relationship is working from primary to secondary
       when: ansible_hostname == hana_database.nodes[0].dbname
       shell: >
-        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[1]].ansible_default_ipv4.address] }} hostname
+        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[1]].ansible_default_ipv4.address] }} "hostname -s"
       register: primary_to_secondary_ssh_result
       changed_when: false
       failed_when: primary_to_secondary_ssh_result != hana_database.nodes[1].dbname
@@ -49,7 +49,7 @@
     - name: Ensure trust relationship is working from secondary to primary
       when: ansible_hostname == hana_database.nodes[1].dbname
       shell: >
-        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[0]].ansible_default_ipv4.address] }} hostname
+        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[0]].ansible_default_ipv4.address] }} "hostname -s"
       register: secondary_to_primary_ssh_result
       changed_when: false
       failed_when: primary_to_secondary_ssh_result != hana_database.nodes[0].dbname

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -1,55 +1,53 @@
 ---
 
 - name: Ensure ssh keys on both nodes
-  become: "{{ sid_admin_user }}"
+  become_user: "{{ sid_admin_user }}"
   block:
     - name: Check for existence of id_rsa file
-      file:
-        path: ~/.ssh/id_rsa
-        state: file
-      check_mode: true
+      stat:
+        path: "~/.ssh/id_rsa"
       register: id_rsa_file_status
+      failed_when: false
 
     - name: Check for existence of id_rsa.pub file
-      file:
-        path: ~/.ssh/id_rsa.pub
-        state: file
-      check_mode: true
+      stat:
+        path: "~/.ssh/id_rsa.pub"
       register: id_rsa_file_pub_status
+      failed_when: false
 
-    - name: Ensure key pair exists
-      when: id_rsa_file_status.failed and id_rsa_file_pub_status.failed
+    - name: Ensure key pair files exist
+      when: not (id_rsa_file_status.stat.exists or id_rsa_file_pub_status.stat.exists)
       shell: >
         ssh-keygen -b 4096 -t rsa -f ~/.ssh/id_rsa -q -N ""
 
     - name: Ensure the Public SSH key is stored in a variable
-      shell: cat /root/.ssh/id_rsa.pub
-      register: cluster_public_ssh_key
+      shell: cat ~/.ssh/id_rsa.pub
+      register: public_ssh_key
 
-    - name: Ensure the Primary Node public key is on the Secondary node
+    - name: Ensure the primary node public key is on the secondary node
       when: ansible_hostname == hana_database.nodes[1].dbname
       authorized_key:
-        user: root
-        key: "{{ hostvars[hana_database.nodes[0]].cluster_public_ssh_key.stdout }}"
+        user: "{{ sid_admin_user }}"
+        key: "{{ hostvars[hana_database.nodes[0].ip_admin_nic].public_ssh_key.stdout }}"
 
-    - name: Ensure the Secondary Node public key is on the Primary node
+    - name: Ensure the secondary node public key is on the primary node
       when: ansible_hostname == hana_database.nodes[0].dbname
       authorized_key:
-        user: root
-        key: "{{ hostvars[hana_database.nodes[1]].cluster_public_ssh_key.stdout }}"
+        user: "{{ sid_admin_user }}"
+        key: "{{ hostvars[hana_database.nodes[1].ip_admin_nic].public_ssh_key.stdout }}"
 
     - name: Ensure trust relationship is working from primary to secondary
       when: ansible_hostname == hana_database.nodes[0].dbname
       shell: >
-        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[1]].ansible_default_ipv4.address] }} "hostname -s"
+        ssh -oStrictHostKeyChecking=no {{ hana_database.nodes[1].ip_admin_nic }} "hostname -s"
       register: primary_to_secondary_ssh_result
       changed_when: false
-      failed_when: primary_to_secondary_ssh_result != hana_database.nodes[1].dbname
+      failed_when: primary_to_secondary_ssh_result.stdout_lines[0] != hana_database.nodes[1].dbname
 
     - name: Ensure trust relationship is working from secondary to primary
       when: ansible_hostname == hana_database.nodes[1].dbname
       shell: >
-        ssh -oStrictHostKeyChecking=no {{ hostvars[hana_database.nodes[0]].ansible_default_ipv4.address] }} "hostname -s"
+        ssh -oStrictHostKeyChecking=no {{ hana_database.nodes[0].ip_admin_nic }} "hostname -s"
       register: secondary_to_primary_ssh_result
       changed_when: false
-      failed_when: primary_to_secondary_ssh_result != hana_database.nodes[0].dbname
+      failed_when: secondary_to_primary_ssh_result.stdout_lines[0] != hana_database.nodes[0].dbname


### PR DESCRIPTION
## Problem

See [Azure/sap-hana#381](https://github.com/Azure/sap-hana/issues/381)

## Description

This PR:

1. Sets up a trusted SSH relationship for the `root` user between the HANA DB nodes.
1. Refactors the `copy_ssfs_keys.yml` task to use Ansible's `synchronize` module.

## Pre-Requisites

1. Ensure you have the Centiq fork of the repo cloned to your workstation: `git clone https://github.com/Centiq/sap-hana.git && cd sap-hana`
1. Ensure you are on the correct branch: `git checkout backlog-items-use-synchronize`
1. Ensure the branch is up to date: `git pull`

## Commitment to Test

- Full testing requires building and provisioning a two-node HA cluster and takes 1-2 hours - maybe longer if you hit Azure demand issues! Alternatively, you may review the pre-canned Ansible output at the bottom of these instructions.
- Reviewing new/changed files.

## Test Instructions / Acceptance Criteria

- [x] Code changes are acceptable.
- [x] Review the Ansible output for the `hana-system-replication` role, below for completeness.

### Build an HA Cluster

1. Follow the [usage document](https://github.com/Azure/sap-hana/blob/master/deploy/v2/USAGE.md), specifying `clustered_hana` as the template.
   - [ ] Infrastructure built successfully.
1. Log in to the RTI (the IP address is reported at the end of the infrastructure build).
1. Delete the pre-existing `sap-hana` cloned repo. This is the Azure repo. We want the Centiq fork: `rm -rf sap-hana`
1. Clone the Centiq fork: `git clone https://github.com/Centiq/sap-hana.git`
1. Navigate to the `sap-hana` root, checkout the correct branch and ensure up-to-date:

   ```text
   cd sap-hana
   git checkout backlog-items-use-synchronize
   git pull
   ```

1. Manually reconfigure the DB hosts to avoid [spontaneous hostname changes to `linux`](https://github.com/Azure/sap-hana/issues/346). :hand: run commands separately:

   ```text
   ansible hanadbnodes -i ~/hosts -b -a "sed -i 's/DHCLIENT_SET_HOSTNAME=.*/DHCLIENT_SET_HOSTNAME=\"no\"/' /etc/sysconfig/network/dhcp"
   ssh 10.1.1.4 "sudo hostname hdb1-0"
   ssh 10.1.1.5 "sudo hostname hdb1-1"
   ```

1. Navigate to the repo's `ansible` folder and execute the `sap_playbook.yml`:

   ```text
   cd deploy/v2/ansible
   ansible-playbook -i ~/hosts sap_playbook.yml
   ```

   - [ ] Playbook completes with no errors for `hdb1-0` and `hdb1-1`. :hand: You may see errors with other VMs.

<details>
<summary>Ansible Output (from start of `hana-system-replication` role)</summary>

```text
TASK [hana-system-replication : Check HANA system replication variables are set and seem valid] **********************************************************************************************
ok: [10.1.1.4] => {
    "changed": false,
    "msg": "All assertions passed"
}
ok: [10.1.1.5] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [hana-system-replication : Check that HANA was installed successfully and is running normally] ******************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Check whether replication has already been set up] ***********************************************************************************************************
ok: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Ensure current replication status is known] ******************************************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Check that HANA DB SYSTEM user can access the SYSTEM database] ***********************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Check that HANA DB SYSTEM user can access the tenant database HN1] *******************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Check HANA log mode is set to normal] ************************************************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Check for existence of id_rsa file] **************************************************************************************************************************
ok: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Check for existence of id_rsa.pub file] **********************************************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure key pair files exist] *********************************************************************************************************************************
skipping: [10.1.1.4]
skipping: [10.1.1.5]

TASK [hana-system-replication : Ensure the Public SSH key is stored in a variable] ***********************************************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure the primary node public key is on the secondary node] *************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure the secondary node public key is on the primary node] *************************************************************************************************
skipping: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Ensure trust relationship is working from primary to secondary] **********************************************************************************************
skipping: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Ensure trust relationship is working from secondary to primary] **********************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Check SSFS_HN1.DAT backup file exists on the secondary node] *************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure SSFS_HN1.DAT file is backed up on the secondary node] *************************************************************************************************
skipping: [10.1.1.4]
skipping: [10.1.1.5]

TASK [hana-system-replication : Check SSFS_HN1.KEY backup file exists on the secondary node] *************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure SSFS_HN1.KEY file is backed up on the secondary node] *************************************************************************************************
skipping: [10.1.1.4]
skipping: [10.1.1.5]

TASK [hana-system-replication : Ensure original SSFS_HN1.DAT file is removed on the secondary node] ******************************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5]

TASK [hana-system-replication : Ensure original SSFS_HN1.KEY file is removed on the secondary node] ******************************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5]

TASK [hana-system-replication : Ensure the primary node SSFS_HN1.DAT file is placed on the secondary node] ***********************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5 -> 10.1.1.4]

TASK [hana-system-replication : Ensure the primary node SSFS_HN1.KEY file is placed on the secondary node] ***********************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5 -> 10.1.1.4]

TASK [hana-system-replication : Ensure backup directory exists for HANA database with System Identifier HN1] *********************************************************************************
changed: [10.1.1.4]
changed: [10.1.1.5]

TASK [hana-system-replication : Check whether backup exists for SYSTEMDB database for System Identifier HN1] *********************************************************************************
ok: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Ensure backup exists for SYSTEMDB database for System Identifier HN1] ****************************************************************************************
[DEPRECATION WARNING]: evaluating ('BACKUP_ID\n0 rows selected' in backup_exists_cmd_for_systemdb_result.stdout) | bool as a bare variable, this behaviour will go away and you might need to
 add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: evaluating ('BACKUP_ID\n0 rows selected' in backup_exists_cmd_for_systemdb_result.stdout) | bool as a bare variable, this behaviour will go away and you might need to
 add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
changed: [10.1.1.5]
changed: [10.1.1.4]

TASK [hana-system-replication : Check whether backup exists for tenant HN1 database for System Identifier HN1] *******************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure backup exists for tenant HN1 database for System Identifier HN1] **************************************************************************************
[DEPRECATION WARNING]: evaluating ('BACKUP_ID\n0 rows selected' in backup_exists_cmd_for_tenant_result.stdout) | bool as a bare variable, this behaviour will go away and you might need to 
add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: evaluating ('BACKUP_ID\n0 rows selected' in backup_exists_cmd_for_tenant_result.stdout) | bool as a bare variable, this behaviour will go away and you might need to 
add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
changed: [10.1.1.5]
changed: [10.1.1.4]

TASK [hana-system-replication : Check backup file exists for SYSTEMDB database for System Identifier HN1] ************************************************************************************
ok: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Check backup file exists for tenant HN1 database for System Identifier HN1] **********************************************************************************
ok: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure Primary node is configured for System Replication] ****************************************************************************************************
skipping: [10.1.1.5]
changed: [10.1.1.4]

TASK [hana-system-replication : Check replication state on primary] **************************************************************************************************************************
skipping: [10.1.1.5]
ok: [10.1.1.4]

TASK [hana-system-replication : Determine if HANA is stopped] ********************************************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure HANA is stopped] **************************************************************************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5]

TASK [hana-system-replication : Check HANA is stopped] ***************************************************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure Secondary node is registered as secondary in replication] *********************************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5]

TASK [hana-system-replication : Determine if HANA is running] ********************************************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure HANA is running] **************************************************************************************************************************************
skipping: [10.1.1.4]
changed: [10.1.1.5]

TASK [hana-system-replication : Check HANA is running] ***************************************************************************************************************************************
skipping: [10.1.1.4]
ok: [10.1.1.5]

TASK [hana-system-replication : Ensure replication status is active] *************************************************************************************************************************
skipping: [10.1.1.5]
FAILED - RETRYING: Ensure replication status is active (30 retries left).
ok: [10.1.1.4]

PLAY RECAP ***********************************************************************************************************************************************************************************
10.1.1.4                   : ok=23   changed=4    unreachable=0    failed=0    skipped=18   rescued=0    ignored=0   
10.1.1.5                   : ok=33   changed=10   unreachable=0    failed=0    skipped=8    rescued=0    ignored=0   
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

</details>
