### PR TITLE
Set configurable replicationMode and operationMode

### DIFF
--- a/deploy/v2/ansible/roles/hana-system-replication/defaults/main.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/defaults/main.yml
@@ -12,6 +12,8 @@
 sid: "HN1"
 instance_number: "00"
 hana_system_user_password: "PassWord"
+hana_replication_mode: "sync"
+hana_operation_mode: "logReplay"
 
 # For low spec Dev instances the timeout needs to be high
 # A delay of 2 seconds is also recommended

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
@@ -56,8 +56,8 @@
       shell: >
         source ~/.bashrc ;
         {{ hdbnsutil_command }} -sr_register --remoteHost={{ hana_database.nodes[0].dbname }}
-        --remoteInstance={{ instance_number }} --replicationMode=sync
-        --operationMode=logreplay --name=SITEB
+        --remoteInstance={{ instance_number }} --replicationMode={{  hana_replication_mode }}
+        --operationMode={{ hana_operation_mode }} --name=SITEB
       tags:
         - skip_ansible_lint
 


### PR DESCRIPTION
## Problem

See [Azure/sap-hana#382](https://github.com/Azure/sap-hana/issues/382)

## Description

This PR creates two new default values for HANA replicationMode and operationMode.

## Pre-Requisites

None.

## Commitment to Test

- Reviewing changed files.

## Test Instructions /  Acceptance Criteria

- [ ] Changes are acceptable
