### PR TITLE
HANA DB backup on primary node only

### DIFF
--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/create_hana_backup.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/create_hana_backup.yml
@@ -6,9 +6,9 @@
     state: directory
     owner: "{{ sid_admin_user }}"
 
-- name: Ensure backups are taken
+- name: Ensure backup is taken on primary node
   # If HSR is already enabled, we don't need to do this
-  when: not hana_system_replication_enabled
+  when: ansible_hostname == hana_database.nodes[0].dbname and not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   block:
     - name: Check whether backup exists for SYSTEMDB database for System Identifier {{ sid }}

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
@@ -2,8 +2,7 @@
 
 - name: Perform pre-flight backup checks
   become_user: "{{ sid_admin_user }}"
-  # If HSR is already enabled, we cannot read from the secondary node
-  when: (ansible_hostname == hana_database.nodes[0].dbname) or not hana_system_replication_enabled
+  when: ansible_hostname == hana_database.nodes[0].dbname
   block:
 
     - name: Check backup file exists for SYSTEMDB database for System Identifier {{ sid }}


### PR DESCRIPTION
## Problem

See [Azure/sap-hana#407](https://github.com/Azure/sap-hana/issues/407)

## Description

This PR:

- Takes a full backup on the primary node only
- Checks the backup on the primary node only

## Pre-Requisites

None.

## Commitment to Test

- Review changed files.

## Test Instructions / Acceptance Criteria

- [x] Code changes to run/check backup only on the primary node are acceptable.

