### PR TITLE
Ensure the cluster SP details file is on the RTI for use by ansible

### DIFF
--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -91,7 +91,7 @@ resource "null_resource" "ansible_playbook" {
       "curl -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_finished\" http://169.254.169.254/metadata/instance?api-version=${var.api-version}",
       "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
       "export ANSIBLE_HOST_KEY_CHECKING=False",
-      "/bin/bash ~/export-clustering-sp-details.sh",
+      "source ~/export-clustering-sp-details.sh",
       var.options.ansible_execution ? "ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml" : "ansible-playbook --version"
     ]
   }

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -91,6 +91,7 @@ resource "null_resource" "ansible_playbook" {
       "curl -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_finished\" http://169.254.169.254/metadata/instance?api-version=${var.api-version}",
       "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
       "export ANSIBLE_HOST_KEY_CHECKING=False",
+      "/bin/bash ~/export-clustering-sp-details.sh",
       var.options.ansible_execution ? "ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml" : "ansible-playbook --version"
     ]
   }

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -269,6 +269,12 @@ resource "null_resource" "prepare-rti" {
     destination = "/home/${local.rti-info[0].authentication.username}"
   }
 
+  # Copies Clustering Service Principal for ansbile on RTI.
+  provisioner "file" {
+    content     = fileexists("${path.cwd}/set-clustering-auth-${local.hana-sid}.sh") ? file("${path.cwd}/set-clustering-auth-${local.hana-sid}.sh") : ""
+    destination = "/home/${local.rti-info[0].authentication.username}/export-clustering-sp-details.sh"
+  }
+
   # Installs Git, Ansible and clones repository on RTI
   provisioner "remote-exec" {
     inline = [

--- a/deploy/v2/terraform/modules/jumpbox/variables_local.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables_local.tf
@@ -36,4 +36,11 @@ locals {
     }
     if jumpbox-linux.destroy_after_deploy == "true"
   ]
+  hana-sid = length([
+    for database in var.databases : database
+    if database.platform == "HANA"
+  ]) > 0 ? element([
+    for database in var.databases : database.instance.sid
+    if database.platform == "HANA"
+  ], 0) : ""
 }


### PR DESCRIPTION
Patching into #19 the ability to copy the generated SP file and source it prior to running ansible. This enables the clustering/fencing agent configuration values to be available to ansible running on the RTI