### PR TITLE
Check that sap_user and sap_password have been set before applying Terraform builds

### DIFF
--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -113,3 +113,25 @@ function edit_json_template_for_path()
 	# replace original JSON template file with temporary edited one
 	mv "${temp_template_json}" "${target_json}"
 }
+
+
+# This helper funciton checks if a JSON key is set to a non-empty string
+# the json_path argument must be in jq dot notation, e.g. '.software.downloader.credentials.sap_user'
+function check_json_value_is_not_empty()
+{
+	local json_path="$1"
+	local json_template_name="$2"
+	local target_json="${target_template_dir}/${json_template_name}.json"
+
+	check_file_exists "${target_json}"
+
+	check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
+
+	local json_value="$(jq ${json_path} ${target_json})"
+
+	if [ "${json_value}" == '""' ]; then
+		return 1
+	else
+		return 0
+	fi
+}

--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -127,7 +127,8 @@ function check_json_value_is_not_empty()
 
 	check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
 
-	local json_value="$(jq ${json_path} ${target_json})"
+	local json_value=
+	json_value=$(jq "${json_path}" "${target_json}")
 
 	if [ "${json_value}" == '""' ]; then
 		return 1

--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -143,6 +143,14 @@ function terraform_apply()
 
 	check_json_template_exists "${target_json_template}"
 
+	# Check if the sap_user and sap_password values have been set
+	if ! check_json_value_is_not_empty ".software.downloader.credentials.sap_user" "${target_json_template}"; then
+		error_and_exit "sap_user is not set, run util/set_sap_download_credentials.sh"
+	fi
+	if ! check_json_value_is_not_empty ".software.downloader.credentials.sap_password" "${target_json_template}"; then
+		error_and_exit "sap_password is not set, run util/set_sap_download_credentials.sh"
+	fi
+
 	local target_json
 	target_json=$(get_json_template_path "${target_json_template}")
 	run_terraform_command "apply -auto-approve -var-file=${target_json} ${target_code}"


### PR DESCRIPTION
## Problem

If the SAP credentials have not been set at the point of a Terraform build, then it's only at the point of running the Ansible to download the SAP software that the missing credentials are highlighted.

## Description

This PR provides a simple method for checking if the `sap_user` and `sap_password` values are empty in the targeted template before attempting to apply the Terraform changes.

## Pre-Requisites

None

## Commitment to Test

- Testing takes 5 minutes
- Reviewing 2 files

## Test Instructions/Acceptance Criteria

1. Ensure the `clustered_hana` template is in it's default state:\
   `git checkout -- deploy/v2/template_samples/clustered_hana.json`
1. Attempt deploy the `clustered_hana` template:\
   `util/terraform_v2.sh apply clustered_hana`
   - [x] An error is displayed for the `sap_user` value:\
      `ERROR: sap_user is not set, run util/set_sap_download_credentials.sh`
1. Update the template with a value for `software.downloader.credentials.sap_user`
1. Attempt deploy the `clustered_hana` template:\
   `util/terraform_v2.sh apply clustered_hana`
   - [x] An error is displayed for the `sap_password`:\
      `ERROR: sap_password is not set, run util/set_sap_download_credentials.sh`
1. Set a value for the `sap_password`
1. Start a deployment:\
   `util/terraform_v2.sh apply clustered_hana`
   - [x] The deployment starts
     :hand: Stop the deployment once you start seeing Terraform output.
 