### PR TITLE
Simplify path retrieval

### DIFF
--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/post_checks.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/post_checks.yml
@@ -3,11 +3,12 @@
 - name: Ensure replication status is active
   become_user: "{{ sid_admin_user }}"
   # Note: ideally we should be using set -o pipefail here (see for example https://xanmanning.co.uk/2019/03/21/ansible-lint-rule-306.html).
-  #   However, the python script returns a status of 15 (!), which breaks
-  #   the pipeline. Consequently, no pipefail option and elect to skip Ansible linting of this task.
-  shell: >
-    source ~/.bashrc ;
-    python {{ path_sys_rep_status }} | grep -q 'overall system replication status: ACTIVE'
+  #   However, the python script returns a status of 15 (!), which breaks the pipeline. Consequently,
+  #   no pipefail option and elect to skip Ansible linting of this task.
+  shell: |
+    source ~/.bashrc
+    cdpy
+    (python systemReplicationStatus.py; echo) | grep -q 'overall system replication status: ACTIVE'
   register: grep_result
   until: grep_result.rc == 0
   changed_when: false

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Check runtime value of SAP global path
+- name: Determine runtime value of SAP global path
   become_user: "{{ sid_admin_user }}"
   shell: >
     set -o pipefail && grep '^alias cdglo=' ~/.sapenv.sh | sed -e 's/^.* //' -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' -e "s/'//"
@@ -18,6 +18,21 @@
     path_ssfs_key: "{{ hana_global_dir }}/security/rsecssfs/key/SSFS_{{ sid | upper }}.KEY"
     path_xsa_ssfs_dat: "{{ hana_global_dir }}/xsa/security/ssfs/data/SSFS_{{ sid | upper }}.DAT"
     path_xsa_ssfs_key: "{{ hana_global_dir }}/xsa/security/ssfs/key/SSFS_{{ sid | upper }}.KEY"
+
+- name: Determine runtime value of SAP exe path
+  become_user: "{{ sid_admin_user }}"
+  shell: >
+    set -o pipefail && grep '^alias cdexe=' ~/.sapenv.sh | sed -e 's/^.* //' -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' -e "s/'//"
+  register: exe_path_status
+  changed_when: false
+
+- name: Set SAP exe directory fact
+  set_fact:
+    hana_instance_executable_dir: "{{ global_path_status.stdout_lines[0] }}"
+
+- name: Set associated SAP global directory facts
+  set_fact:
+    path_sys_rep_status: "{{ hana_instance_executable_dir }}/python_support/systemReplicationStatus.py"
 
 - name: Ensure the Primary node SSFS files are present on the primary node
   when: ansible_hostname == hana_database.nodes[0].dbname

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -32,7 +32,7 @@
   loop: "{{ hdb_sizes[hana_database.size].storage }}"
   when: item.name == "backup"
 
-- name: Ensure HANA backup file names are defined
+- name: Ensure HANA backup file names are set
   set_fact:
     backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
     backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -26,7 +26,7 @@
   register: cdpy_path_status
   changed_when: false
 
-- name: Set associated SAP replication status command
+- name: Set associated SAP replication status command path
   set_fact:
     path_sys_rep_status: "{{ cdpy_path_status.stdout_lines[0] }}/python_support/systemReplicationStatus.py"
 

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -19,20 +19,16 @@
     path_xsa_ssfs_dat: "{{ hana_global_dir }}/xsa/security/ssfs/data/SSFS_{{ sid | upper }}.DAT"
     path_xsa_ssfs_key: "{{ hana_global_dir }}/xsa/security/ssfs/key/SSFS_{{ sid | upper }}.KEY"
 
-- name: Determine runtime value of SAP exe path
+- name: Determine runtime value of SAP replication status path
   become_user: "{{ sid_admin_user }}"
   shell: >
-    set -o pipefail && grep '^alias cdexe=' ~/.sapenv.sh | sed -e 's/^.* //' -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' -e "s/'//"
-  register: exe_path_status
+    set -o pipefail && grep '^alias cdpy=' ~/.sapenv.sh | sed -e 's/^.* //' -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' -e "s/'//"
+  register: cdpy_path_status
   changed_when: false
 
-- name: Set SAP exe directory fact
+- name: Set associated SAP replication status command
   set_fact:
-    hana_instance_executable_dir: "{{ global_path_status.stdout_lines[0] }}"
-
-- name: Set associated SAP global directory facts
-  set_fact:
-    path_sys_rep_status: "{{ hana_instance_executable_dir }}/python_support/systemReplicationStatus.py"
+    path_sys_rep_status: "{{ cdpy_path_status.stdout_lines[0] }}/python_support/systemReplicationStatus.py"
 
 - name: Ensure the Primary node SSFS files are present on the primary node
   when: ansible_hostname == hana_database.nodes[0].dbname

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -7,11 +7,11 @@
   register: global_path_status
   changed_when: false
 
-- name: Set SAP global directory fact
+- name: Ensure SAP global directory fact is set
   set_fact:
     hana_global_dir: "{{ global_path_status.stdout_lines[0] }}"
 
-- name: Set associated SAP global directory facts
+- name: Ensure associated SAP global directory facts are set
   set_fact:
     path_global_ini: "{{ hana_global_dir }}/hdb/custom/config/global.ini"
     path_ssfs_dat: "{{ hana_global_dir }}/security/rsecssfs/data/SSFS_{{ sid | upper }}.DAT"
@@ -26,7 +26,7 @@
   register: cdpy_path_status
   changed_when: false
 
-- name: Set associated SAP replication status command path
+- name: Ensure associated SAP replication status command path is set
   set_fact:
     path_sys_rep_status: "{{ cdpy_path_status.stdout_lines[0] }}/python_support/systemReplicationStatus.py"
 

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -19,6 +19,17 @@
     path_xsa_ssfs_dat: "{{ hana_global_dir }}/xsa/security/ssfs/data/SSFS_{{ sid | upper }}.DAT"
     path_xsa_ssfs_key: "{{ hana_global_dir }}/xsa/security/ssfs/key/SSFS_{{ sid | upper }}.KEY"
 
+- name: Determine path of SID backup directory from hdb_sizes.json
+  set_fact:
+    sid_backup_dir: "{{ item.mount_point }}/{{ sid | upper }}"
+  loop: "{{ hdb_sizes[hana_database.size].storage }}"
+  when: item.name == "backup"
+
+- name: Ensure HANA backup file names are set
+  set_fact:
+    backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
+    backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
+
 - name: Determine runtime value of SAP replication status path
   become_user: "{{ sid_admin_user }}"
   shell: >
@@ -30,17 +41,6 @@
 
   register: cdpy_path_status
   changed_when: false
-
-- name: Determine path of SID backup directory from hdb_sizes.json
-  set_fact:
-    sid_backup_dir: "{{ item.mount_point }}/{{ sid | upper }}"
-  loop: "{{ hdb_sizes[hana_database.size].storage }}"
-  when: item.name == "backup"
-
-- name: Ensure HANA backup file names are set
-  set_fact:
-    backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
-    backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
 
 - name: Ensure associated SAP replication status command path is set
   set_fact:

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -37,7 +37,6 @@
     backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
     backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
 
-
 - name: Ensure associated SAP replication status command path is set
   set_fact:
     path_sys_rep_status: "{{ cdpy_path_status.stdout_lines[0] }}/python_support/systemReplicationStatus.py"

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -30,22 +30,6 @@
     backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
     backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
 
-- name: Determine runtime value of SAP replication status path
-  become_user: "{{ sid_admin_user }}"
-  shell: >
-    set -o pipefail && grep '^alias cdpy=' ~/.sapenv.sh |
-    sed -e 's/^.* //' \
-      -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' \
-      -e "s/'//" \
-      -e 's/\\[0-9\\]\\[0-9\\]/{{ instance_number }}/'
-
-  register: cdpy_path_status
-  changed_when: false
-
-- name: Ensure associated SAP replication status command path is set
-  set_fact:
-    path_sys_rep_status: "{{ cdpy_path_status.stdout_lines[0] }}/python_support/systemReplicationStatus.py"
-
 - name: Ensure the Primary node SSFS files are present on the primary node
   when: ansible_hostname == hana_database.nodes[0].dbname
   block:

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -22,7 +22,12 @@
 - name: Determine runtime value of SAP replication status path
   become_user: "{{ sid_admin_user }}"
   shell: >
-    set -o pipefail && grep '^alias cdpy=' ~/.sapenv.sh | sed -e 's/^.* //' -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' -e "s/'//"
+    set -o pipefail && grep '^alias cdpy=' ~/.sapenv.sh |
+    sed -e 's/^.* //' \
+      -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' \
+      -e "s/'//" \
+      -e 's/\\[0-9\\]\\[0-9\\]/{{ instance_number }}/'
+
   register: cdpy_path_status
   changed_when: false
 

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -26,6 +26,18 @@
   register: cdpy_path_status
   changed_when: false
 
+- name: Determine path of SID backup directory from hdb_sizes.json
+  set_fact:
+    sid_backup_dir: "{{ item.mount_point }}/{{ sid | upper }}"
+  loop: "{{ hdb_sizes[hana_database.size].storage }}"
+  when: item.name == "backup"
+
+- name: Ensure HANA backup file names are defined
+  set_fact:
+    backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
+    backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
+
+
 - name: Ensure associated SAP replication status command path is set
   set_fact:
     path_sys_rep_status: "{{ cdpy_path_status.stdout_lines[0] }}/python_support/systemReplicationStatus.py"

--- a/deploy/v2/ansible/roles/hana-system-replication/vars/main.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/vars/main.yml
@@ -14,9 +14,6 @@ sid_admin_user: "{{ sid | lower }}adm"
 hana_data_dir: "{{ hana_dir }}/data"
 hana_backup_dir: "{{ hana_dir }}/backup"
 hana_shared_dir: "{{ hana_dir }}/shared"
-hana_instance_executable_dir: "{{ sap_dir }}/{{ sid | upper }}/HDB{{ instance_number }}/exe"
-
-path_sys_rep_status: "{{ hana_instance_executable_dir }}/python_support/systemReplicationStatus.py"
 
 # HANA Backup directory
 sid_backup_dir: "{{ hana_backup_dir }}/{{ sid | upper }}"

--- a/deploy/v2/ansible/roles/hana-system-replication/vars/main.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/vars/main.yml
@@ -11,15 +11,6 @@ sap_dir: "/usr/sap"
 
 sid_admin_user: "{{ sid | lower }}adm"
 
-hana_data_dir: "{{ hana_dir }}/data"
-hana_backup_dir: "{{ hana_dir }}/backup"
-hana_shared_dir: "{{ hana_dir }}/shared"
-
-# HANA Backup directory
-sid_backup_dir: "{{ hana_backup_dir }}/{{ sid | upper }}"
-backup_file_for_systemdb_full_path: "{{ sid_backup_dir }}/INITIAL_SYSTEMDB_BACKUP"
-backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
-
 # HANA
 hana_container_address: "localhost:3{{ instance_number }}13"
 hana_tenant_address: "localhost:3{{ instance_number }}15"

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -78,6 +78,11 @@
   any_errors_fatal: true
   vars_files:
     - "vars/ha-packages.yml"
+  pre_tasks:
+    - name: Include SAP HANA DB sizes
+      include_vars:
+        file: ../hdb_sizes.json
+        name: hdb_sizes
   roles:
     - role: hdb-server-install
     - role: hana-system-replication


### PR DESCRIPTION
## Problem

See [Azure/sap-hana#384](https://github.com/Azure/sap-hana/issues/384)

## Description

This PR eliminates the hard-coded settings for the variables in the above issue by:

- Note: the hard-coding for the `hana_global_dir` variable was removed in an earlier PR.
- Removing the `hana_data_dir` variable, as it was unused.
- Removing the `hana_shared_dir` variable, as it was unused.
- Removing `path_sys_rep_status`. It was only used in one shell command.
- Removing the `hana_instance_executable_dir` variable, as it was only used to generate `path_sys_rep_status`.
- Removing the `hana_backup_dir` variable, as it was only used to generate `sid_backup_dir`.
- Determining `sid_backup_dir` from the `hdb_sizes.json` file.

## Pre-Requisites

None.

## Commitment to Test

- Testing will be done by the pipeline.
- Reviewing changed files.

## Test Instructions / Acceptance Criteria

- [ ] Confirm code changes match the changes described and appear correct.

