### PR TITLE
"Hardwired" Application Tier Terraform

### DIFF
--- a/deploy/input.json
+++ b/deploy/input.json
@@ -53,6 +53,17 @@
             "arm_id": "",
             "name": ""
           }
+        },
+        "subnet_app": {
+          "is_existing": "",
+          "arm_id": "",
+          "name": "",
+          "prefix": "",
+          "nsg": {
+            "is_existing": "",
+            "arm_id": "",
+            "name": ""
+          }
         }
       }
     },

--- a/deploy/template_samples/clustered_hana.json
+++ b/deploy/template_samples/clustered_hana.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     }

--- a/deploy/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/template_samples/clustered_hana_with_sbd.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     },

--- a/deploy/template_samples/rti_only.json
+++ b/deploy/template_samples/rti_only.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     }

--- a/deploy/template_samples/single_node_hana.json
+++ b/deploy/template_samples/single_node_hana.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     }

--- a/deploy/template_samples/single_node_hana_single_container.json
+++ b/deploy/template_samples/single_node_hana_single_container.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     }

--- a/deploy/terraform/module.tf
+++ b/deploy/terraform/module.tf
@@ -48,6 +48,22 @@ module "hdb_node" {
   storage-bootdiag = module.common_infrastructure.storage-bootdiag
 }
 
+# Create Application Tier nodes
+module "app_tier" {
+  source           = "./modules/app_tier"
+  databases        = var.databases
+  infrastructure   = var.infrastructure
+  jumpboxes        = var.jumpboxes
+  options          = var.options
+  software         = var.software
+  ssh-timeout      = var.ssh-timeout
+  sshkey           = var.sshkey
+  resource-group   = module.common_infrastructure.resource-group
+  subnet-app       = module.common_infrastructure.subnet-sap-app
+  nsg-app          = module.common_infrastructure.nsg-app
+  storage-bootdiag = module.common_infrastructure.storage-bootdiag
+}
+
 # Generate output files
 module "output_files" {
   source                       = "./modules/output_files"

--- a/deploy/terraform/modules/app_tier/app-vm.tf
+++ b/deploy/terraform/modules/app_tier/app-vm.tf
@@ -1,0 +1,7 @@
+# TODO: NIC(s)
+# TODO: NIC/NSG Association
+# TODO: Availability Set
+# TODO: VM(s)
+# TODO: Disk(s)
+# TODO: Disk Attachment
+# TODO: NIC Attachment

--- a/deploy/terraform/modules/app_tier/app-vm.tf
+++ b/deploy/terraform/modules/app_tier/app-vm.tf
@@ -1,7 +1,79 @@
-# TODO: NIC(s)
-# TODO: NIC/NSG Association
-# TODO: Availability Set
-# TODO: VM(s)
-# TODO: Disk(s)
-# TODO: Disk Attachment
-# TODO: NIC Attachment
+# Create Application NICs
+resource "azurerm_network_interface" "nics-app" {
+  count                         = 2
+  name                          = "app${count.index}-${local.sid}-nic"
+  location                      = var.resource-group[0].location
+  resource_group_name           = var.resource-group[0].name
+  enable_accelerated_networking = true
+
+  ip_configuration {
+    name                          = "app${count.index}-${local.sid}-nic-ip"
+    subnet_id                     = var.subnet-app[0].id
+    private_ip_address            = "10.1.3.2${count.index}"
+    private_ip_address_allocation = "static"
+  }
+}
+
+# Associate Application NICs with the Network Security Group
+resource "azurerm_network_interface_security_group_association" "nic-app-nsg" {
+  count                     = 2
+  network_interface_id      = azurerm_network_interface.nics-app[count.index].id
+  network_security_group_id = var.nsg-app[0].id
+}
+
+
+# Create the Application Availability Set
+resource "azurerm_availability_set" "app-as" {
+  count                        = 1
+  name                         = "app-${local.sid}-as"
+  location                     = var.resource-group[0].location
+  resource_group_name          = var.resource-group[0].name
+  platform_update_domain_count = 20
+  platform_fault_domain_count  = 2
+  managed                      = true
+}
+
+# Create the Application VM(s)
+resource "azurerm_linux_virtual_machine" "vm-app" {
+  count               = 2
+  name                = "app${count.index}-${local.sid}-vm"
+  computer_name       = "app${count.index}-${local.sid}-vm"
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
+  availability_set_id = azurerm_availability_set.app-as[0].id
+  network_interface_ids = [
+    azurerm_network_interface.nics-app[count.index].id
+  ]
+  size                            = "Standard_D4a_v4"
+  admin_username                  = "appadmin"
+  admin_password                  = "password"
+  disable_password_authentication = true
+
+  os_disk {
+    name                 = "app${count.index}-osdisk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "suse"
+    offer     = "sles-sap-12-sp5"
+    sku       = "gen1"
+    version   = "latest"
+  }
+
+  admin_ssh_key {
+    username   = "appadmin"
+    public_key = file(var.sshkey.path_to_public_key)
+  }
+
+  boot_diagnostics {
+    storage_account_uri = var.storage-bootdiag.primary_blob_endpoint
+  }
+}
+
+# TODO: Disk(s) ?
+# Do we need additional data disk?
+
+
+# TODO: Disk Attachment ?

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -1,0 +1,2 @@
+# TODO: SubNet
+# TODO: NSG

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -112,10 +112,10 @@ resource "azurerm_availability_set" "scs-as" {
 }
 
 # Create the SCS VM(s)
-resource "azurerm_linux_virtual_machine" "vm-dbnode" {
+resource "azurerm_linux_virtual_machine" "vm-scs" {
   count               = 2
-  name                = "${count.index == 0 ? "scs" : "ers"}-${local.sid}-vm"
-  computer_name       = "${count.index == 0 ? "scs" : "ers"}-${local.sid}-vm"
+  name                = "scs${count.index}-${local.sid}-vm"
+  computer_name       = "scs${count.index}-${local.sid}-vm"
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
   availability_set_id = azurerm_availability_set.scs-as[0].id
@@ -128,7 +128,7 @@ resource "azurerm_linux_virtual_machine" "vm-dbnode" {
   disable_password_authentication = true
 
   os_disk {
-    name                 = "${count.index == 0 ? "scs" : "ers"}-osdisk"
+    name                 = "scs${count.index}-osdisk"
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -145,10 +145,9 @@ resource "azurerm_linux_virtual_machine" "vm-dbnode" {
     public_key = file(var.sshkey.path_to_public_key)
   }
 
-  # TODO: Boot diagnostics?
-  # boot_diagnostics {
-  #   storage_account_uri = var.storage-bootdiag.primary_blob_endpoint
-  # }
+  boot_diagnostics {
+    storage_account_uri = var.storage-bootdiag.primary_blob_endpoint
+  }
 }
 
 # TODO: Disk(s) ?

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -9,7 +9,7 @@ resource "azurerm_network_interface" "nics-scs" {
   ip_configuration {
     name                          = "scs-${local.sid}-nic-${count.index}-ip"
     subnet_id                     = var.subnet-app[0].id
-    private_ip_address            = "10.1.3.10"
+    private_ip_address            = "10.1.3.1${count.index}"
     private_ip_address_allocation = "static"
   }
 }
@@ -88,7 +88,7 @@ resource "azurerm_lb_rule" "ers-lb-rules" {
   backend_port                   = local.lb-ports.ers[count.index]
   frontend_ip_configuration_name = "ers-${local.sid}-lb-feip"
   backend_address_pool_id        = azurerm_lb_backend_address_pool.scs-lb-back-pool[0].id
-  probe_id                       = azurerm_lb_probe.scs-lb-health-probe[0].id
+  probe_id                       = azurerm_lb_probe.scs-lb-health-probe[1].id
   enable_floating_ip             = true
 }
 

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -21,28 +21,37 @@ resource "azurerm_network_interface_security_group_association" "nic-scs-nsg" {
 
 # TODO: Load Balancer
 resource "azurerm_lb" "scs-lb" {
-  name                = "scs-${locals.sid}-lb"
+  name                = "scs-${local.sid}-lb"
   resource_group_name = var.resource-group[0].name
   location            = var.resource-group[0].location
 
-  frontend_ip_configuration {
-    name                          = "scs-${locals.sid}-lb-feip"
-    subnet_id                     = var.subnet-sap-db[0].id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = "10.1.3.5"
-  }
+  frontend_ip_configuration = [
+    {
+      name                          = "scs-${local.sid}-lb-feip"
+      subnet_id                     = var.subnet-sap-db[0].id
+      private_ip_address_allocation = "Static"
+      private_ip_address            = "10.1.3.5"
+    }
+
+    {
+      name                          = "ers-${local.sid}-lb-feip"
+      subnet_id                     = var.subnet-sap-db[0].id
+      private_ip_address_allocation = "Static"
+      private_ip_address            = "10.1.3.6"
+    }
+  ]
 }
 
 resource "azurerm_lb_backend_address_pool" "scs-lb-back-pool" {
   resource_group_name = var.resource-group[0].name
   loadbalancer_id     = azurerm_lb.scs-lb.id
-  name                = "scs-${locals.sid}-lb-bep"
+  name                = "scs-${local.sid}-lb-bep"
 }
 
 resource "azurerm_lb_probe" "scs-lb-health-probe" {
   resource_group_name = var.resource-group[0].name
   loadbalancer_id     = azurerm_lb.scs-lb.id
-  name                = "scs-${locals.sid}-lb-hp"
+  name                = "scs-${local.sid}-lb-hp"
   port                = "620${var.scs_instance_number}"
   protocol            = "Tcp"
   interval_in_seconds = 5
@@ -50,7 +59,33 @@ resource "azurerm_lb_probe" "scs-lb-health-probe" {
 }
 
 # TODO: LB Rules
+resource "azurerm_lb_rule" "scs-lb-rules" {
+  count                          = length(local.lb-ports.scs)
+  resource_group_name            = var.resource-group[0].name
+  loadbalancer_id                = azurerm_lb.scs-lb.id
+  name                           = "SCS_${local.sid}_${local.lb-ports.scs[count.index]}"
+  protocol                       = "Tcp"
+  frontend_port                  = local.lb-ports.scs[count.index]
+  backend_port                   = local.lb-ports.scs[count.index]
+  frontend_ip_configuration_name = "scs-${local.sid}-lb-feip"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.scs-lb-back-pool[0].id
+  probe_id                       = azurerm_lb_probe.scs-lb-health-probe[0].id
+  enable_floating_ip             = true
+}
 
+resource "azurerm_lb_rule" "ers-lb-rules" {
+  count                          = length(local.lb-ports.ers)
+  resource_group_name            = var.resource-group[0].name
+  loadbalancer_id                = azurerm_lb.scs-lb.id
+  name                           = "ERS_${local.sid}_${local.lb-ports.ers[count.index]}"
+  protocol                       = "Tcp"
+  frontend_port                  = local.lb-ports.ers[count.index]
+  backend_port                   = local.lb-ports.ers[count.index]
+  frontend_ip_configuration_name = "ers-${local.sid}-lb-feip"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.scs-lb-back-pool[0].id
+  probe_id                       = azurerm_lb_probe.ers-lb-health-probe[0].id
+  enable_floating_ip             = true
+}
 
 # TODO: LB/NIC Association
 

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -1,0 +1,70 @@
+# Create SCS NIC
+resource "azurerm_network_interface" "nics-scs" {
+  name                          = "scs-nic-1"
+  location                      = var.resource-group[0].location
+  resource_group_name           = var.resource-group[0].name
+  enable_accelerated_networking = true
+
+  ip_configuration {
+    name                          = "scs-nic-1-ip"
+    subnet_id                     = "TBC"
+    private_ip_address            = "10.1.3.10"
+    private_ip_address_allocation = "static"
+  }
+}
+
+# Associate NIC with
+resource "azurerm_network_interface_security_group_association" "nic-scs-nsg" {
+  network_interface_id      = azurerm_network_interface.nics-scs.id
+  network_security_group_id = "TBC"
+}
+
+# TODO: Load Balancer
+resource "azurerm_lb" "scs-lb" {
+  name                = "scs-${locals.sid}-lb"
+  resource_group_name = var.resource-group[0].name
+  location            = var.resource-group[0].location
+
+  frontend_ip_configuration {
+    name                          = "scs-${locals.sid}-lb-feip"
+    subnet_id                     = var.subnet-sap-db[0].id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = "10.1.3.5"
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "scs-lb-back-pool" {
+  resource_group_name = var.resource-group[0].name
+  loadbalancer_id     = azurerm_lb.scs-lb.id
+  name                = "scs-${locals.sid}-lb-bep"
+}
+
+resource "azurerm_lb_probe" "scs-lb-health-probe" {
+  resource_group_name = var.resource-group[0].name
+  loadbalancer_id     = azurerm_lb.scs-lb.id
+  name                = "scs-${locals.sid}-lb-hp"
+  port                = "620${var.scs_instance_number}"
+  protocol            = "Tcp"
+  interval_in_seconds = 5
+  number_of_probes    = 2
+}
+
+# TODO: LB Rules
+
+
+# TODO: LB/NIC Association
+
+
+# TODO: Availability Set
+
+
+# TODO: VM(s)
+
+
+# TODO: Disk(s)
+
+
+# TODO: Disk Attachment
+
+
+# TODO: NIC Attachment

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -1,68 +1,72 @@
-# Create SCS NIC
+# Create SCS NICs
 resource "azurerm_network_interface" "nics-scs" {
-  name                          = "scs-nic-1"
+  count                         = 2
+  name                          = "scs-${local.sid}-nic-${count.index}"
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
   enable_accelerated_networking = true
 
   ip_configuration {
-    name                          = "scs-nic-1-ip"
-    subnet_id                     = "TBC"
+    name                          = "scs-${local.sid}-nic-${count.index}-ip"
+    subnet_id                     = var.subnet-app[0].id
     private_ip_address            = "10.1.3.10"
     private_ip_address_allocation = "static"
   }
 }
 
-# Associate NIC with
+# Associate SCS NICs with the Network Security Group
 resource "azurerm_network_interface_security_group_association" "nic-scs-nsg" {
-  network_interface_id      = azurerm_network_interface.nics-scs.id
-  network_security_group_id = "TBC"
+  count                     = 2
+  network_interface_id      = azurerm_network_interface.nics-scs[count.index].id
+  network_security_group_id = var.nsg-app[0].id
 }
 
-# TODO: Load Balancer
+# Create the SCS Load Balancer
 resource "azurerm_lb" "scs-lb" {
+  count               = 1
   name                = "scs-${local.sid}-lb"
   resource_group_name = var.resource-group[0].name
   location            = var.resource-group[0].location
 
-  frontend_ip_configuration = [
-    {
-      name                          = "scs-${local.sid}-lb-feip"
-      subnet_id                     = var.subnet-sap-db[0].id
-      private_ip_address_allocation = "Static"
-      private_ip_address            = "10.1.3.5"
-    }
+  frontend_ip_configuration {
+    name                          = "scs-${local.sid}-lb-feip"
+    subnet_id                     = var.subnet-app[0].id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = "10.1.3.5"
+  }
 
-    {
-      name                          = "ers-${local.sid}-lb-feip"
-      subnet_id                     = var.subnet-sap-db[0].id
-      private_ip_address_allocation = "Static"
-      private_ip_address            = "10.1.3.6"
-    }
-  ]
+  # TODO: Base this on the HA parameter
+  frontend_ip_configuration {
+    name                          = "ers-${local.sid}-lb-feip"
+    subnet_id                     = var.subnet-app[0].id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = "10.1.3.6"
+  }
 }
 
 resource "azurerm_lb_backend_address_pool" "scs-lb-back-pool" {
+  count               = 1
   resource_group_name = var.resource-group[0].name
-  loadbalancer_id     = azurerm_lb.scs-lb.id
+  loadbalancer_id     = azurerm_lb.scs-lb[0].id
   name                = "scs-${local.sid}-lb-bep"
 }
 
 resource "azurerm_lb_probe" "scs-lb-health-probe" {
+  count               = 2
   resource_group_name = var.resource-group[0].name
-  loadbalancer_id     = azurerm_lb.scs-lb.id
-  name                = "scs-${local.sid}-lb-hp"
-  port                = "620${var.scs_instance_number}"
+  loadbalancer_id     = azurerm_lb.scs-lb[0].id
+  name                = "${count.index == 0 ? "scs" : "ers"}-${local.sid}-lb-hp"
+  port                = local.hp-ports[count.index]
   protocol            = "Tcp"
   interval_in_seconds = 5
   number_of_probes    = 2
 }
 
-# TODO: LB Rules
+# Create the SCS/ERS Load Balancer Rules
 resource "azurerm_lb_rule" "scs-lb-rules" {
   count                          = length(local.lb-ports.scs)
   resource_group_name            = var.resource-group[0].name
-  loadbalancer_id                = azurerm_lb.scs-lb.id
+  loadbalancer_id                = azurerm_lb.scs-lb[0].id
   name                           = "SCS_${local.sid}_${local.lb-ports.scs[count.index]}"
   protocol                       = "Tcp"
   frontend_port                  = local.lb-ports.scs[count.index]
@@ -73,33 +77,82 @@ resource "azurerm_lb_rule" "scs-lb-rules" {
   enable_floating_ip             = true
 }
 
+# TODO: Base this on the HA parameter
 resource "azurerm_lb_rule" "ers-lb-rules" {
   count                          = length(local.lb-ports.ers)
   resource_group_name            = var.resource-group[0].name
-  loadbalancer_id                = azurerm_lb.scs-lb.id
+  loadbalancer_id                = azurerm_lb.scs-lb[0].id
   name                           = "ERS_${local.sid}_${local.lb-ports.ers[count.index]}"
   protocol                       = "Tcp"
   frontend_port                  = local.lb-ports.ers[count.index]
   backend_port                   = local.lb-ports.ers[count.index]
   frontend_ip_configuration_name = "ers-${local.sid}-lb-feip"
   backend_address_pool_id        = azurerm_lb_backend_address_pool.scs-lb-back-pool[0].id
-  probe_id                       = azurerm_lb_probe.ers-lb-health-probe[0].id
+  probe_id                       = azurerm_lb_probe.scs-lb-health-probe[0].id
   enable_floating_ip             = true
 }
 
-# TODO: LB/NIC Association
+# Associate SCS VM NICs with the Load Balancer Backend Address Pool
+resource "azurerm_network_interface_backend_address_pool_association" "scs-lb-nic-bep" {
+  count                   = length(azurerm_network_interface.nics-scs)
+  network_interface_id    = azurerm_network_interface.nics-scs[count.index].id
+  ip_configuration_name   = azurerm_network_interface.nics-scs[count.index].ip_configuration[0].name
+  backend_address_pool_id = azurerm_lb_backend_address_pool.scs-lb-back-pool[0].id
+}
+
+# Create the SCS Availability Set
+resource "azurerm_availability_set" "scs-as" {
+  count                        = 1
+  name                         = "scs-${local.sid}-as"
+  location                     = var.resource-group[0].location
+  resource_group_name          = var.resource-group[0].name
+  platform_update_domain_count = 20
+  platform_fault_domain_count  = 2
+  managed                      = true
+}
+
+# Create the SCS VM(s)
+resource "azurerm_linux_virtual_machine" "vm-dbnode" {
+  count               = 2
+  name                = "${count.index == 0 ? "scs" : "ers"}-${local.sid}-vm"
+  computer_name       = "${count.index == 0 ? "scs" : "ers"}-${local.sid}-vm"
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
+  availability_set_id = azurerm_availability_set.scs-as[0].id
+  network_interface_ids = [
+    azurerm_network_interface.nics-scs[count.index].id
+  ]
+  size                            = "Standard_D4a_v4"
+  admin_username                  = "scsadmin"
+  admin_password                  = "password"
+  disable_password_authentication = true
+
+  os_disk {
+    name                 = "${count.index == 0 ? "scs" : "ers"}-osdisk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "suse"
+    offer     = "sles-sap-12-sp5"
+    sku       = "gen1"
+    version   = "latest"
+  }
+
+  admin_ssh_key {
+    username   = "scsadmin"
+    public_key = file(var.sshkey.path_to_public_key)
+  }
+
+  # TODO: Boot diagnostics?
+  # boot_diagnostics {
+  #   storage_account_uri = var.storage-bootdiag.primary_blob_endpoint
+  # }
+}
+
+# TODO: Disk(s) ?
+# Do we need additional data disk?
 
 
-# TODO: Availability Set
-
-
-# TODO: VM(s)
-
-
-# TODO: Disk(s)
-
-
-# TODO: Disk Attachment
-
-
-# TODO: NIC Attachment
+# TODO: Disk Attachment ?

--- a/deploy/terraform/modules/app_tier/variables_global.tf
+++ b/deploy/terraform/modules/app_tier/variables_global.tf
@@ -1,0 +1,7 @@
+variable "databases" {}
+variable "infrastructure" {}
+variable "jumpboxes" {}
+variable "options" {}
+variable "software" {}
+variable "ssh-timeout" {}
+variable "sshkey" {}

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -1,0 +1,44 @@
+variable "resource-group" {
+  description = "Details of the resource group"
+}
+
+variable "subnet-app" {
+  description = "Details of the SAP Application subnet"
+}
+
+variable "nsg-app" {
+  description = "Details of the SAP Application subnet NSG"
+}
+
+locals {
+  # Filter the list of databases to only HANA platform entries
+  hana-databases = [
+    for database in var.databases : database
+    if database.platform == "HANA"
+  ]
+
+  sid = locals.hana-databases[0].instance.sid
+
+  # Ports used for specific ASCS and ERS
+  scs_lb_ports = {
+    "scs" = [
+      "3200",
+      "3600",
+      "3900",
+      "8100",
+      "50013",
+      "50014",
+      "50016",
+    ]
+
+    "ers" = [
+      "3200",
+      "3300",
+      "50013",
+      "50014",
+      "50016",
+    ]
+  }
+
+  # TODO: logic for generating instance number specific ports
+}

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -10,6 +10,16 @@ variable "nsg-app" {
   description = "Details of the SAP Application subnet NSG"
 }
 
+variable "scs-instance-number" {
+  description = "Instance Number for the SCS instance"
+  default = "01"
+}
+
+variable "ers-instance-number" {
+  description = "Instance Number for the ERS instance in HA deployments"
+  default = "02"
+}
+
 locals {
   # Filter the list of databases to only HANA platform entries
   hana-databases = [
@@ -20,23 +30,23 @@ locals {
   sid = locals.hana-databases[0].instance.sid
 
   # Ports used for specific ASCS and ERS
-  scs_lb_ports = {
+  lb-ports = {
     "scs" = [
-      "3200",
-      "3600",
-      "3900",
-      "8100",
-      "50013",
-      "50014",
-      "50016",
+      3200 + tonumber(var.scs-instance-number),           # e.g. 3201
+      3600 + tonumber(var.scs-instance-number),           # e.g. 3601
+      3900 + tonumber(var.scs-instance-number),           # e.g. 3901
+      8100 + tonumber(var.scs-instance-number),           # e.g. 8101
+      50013 + (tonumber(var.scs-instance-number) * 100),  # e.g. 50113
+      50014 + (tonumber(var.scs-instance-number) * 100),  # e.g. 50114
+      50016 + (tonumber(var.scs-instance-number) * 100),  # e.g. 50116
     ]
 
     "ers" = [
-      "3200",
-      "3300",
-      "50013",
-      "50014",
-      "50016",
+      3200 + tonumber(var.ers-instance-number),          # e.g. 3202
+      3300 + tonumber(var.ers-instance-number),          # e.g. 3302
+      50013 + (tonumber(var.ers-instance-number) * 100), # e.g. 50213
+      50014 + (tonumber(var.ers-instance-number) * 100), # e.g. 50214
+      50016 + (tonumber(var.ers-instance-number) * 100), # e.g. 50216
     ]
   }
 

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -10,14 +10,16 @@ variable "nsg-app" {
   description = "Details of the SAP Application subnet NSG"
 }
 
-variable "scs-instance-number" {
-  description = "Instance Number for the SCS instance"
-  default = "01"
+variable "app-tier" {
+  description = "Details of the SAP Application Tier"
+  default = [{
+    scs-instance-number = "01"
+    ers-instance-number = "02"
+  }]
 }
 
-variable "ers-instance-number" {
-  description = "Instance Number for the ERS instance in HA deployments"
-  default = "02"
+variable "storage-bootdiag" {
+  description = "Details of the boot diagnostic storage device"
 }
 
 locals {
@@ -27,28 +29,35 @@ locals {
     if database.platform == "HANA"
   ]
 
-  sid = locals.hana-databases[0].instance.sid
+  sid = local.hana-databases[0].instance.sid
 
   # Ports used for specific ASCS and ERS
   lb-ports = {
     "scs" = [
-      3200 + tonumber(var.scs-instance-number),           # e.g. 3201
-      3600 + tonumber(var.scs-instance-number),           # e.g. 3601
-      3900 + tonumber(var.scs-instance-number),           # e.g. 3901
-      8100 + tonumber(var.scs-instance-number),           # e.g. 8101
-      50013 + (tonumber(var.scs-instance-number) * 100),  # e.g. 50113
-      50014 + (tonumber(var.scs-instance-number) * 100),  # e.g. 50114
-      50016 + (tonumber(var.scs-instance-number) * 100),  # e.g. 50116
+      3200 + tonumber(var.app-tier[0].scs-instance-number),           # e.g. 3201
+      3600 + tonumber(var.app-tier[0].scs-instance-number),           # e.g. 3601
+      3900 + tonumber(var.app-tier[0].scs-instance-number),           # e.g. 3901
+      8100 + tonumber(var.app-tier[0].scs-instance-number),           # e.g. 8101
+      50013 + (tonumber(var.app-tier[0].scs-instance-number) * 100),  # e.g. 50113
+      50014 + (tonumber(var.app-tier[0].scs-instance-number) * 100),  # e.g. 50114
+      50016 + (tonumber(var.app-tier[0].scs-instance-number) * 100),  # e.g. 50116
     ]
 
     "ers" = [
-      3200 + tonumber(var.ers-instance-number),          # e.g. 3202
-      3300 + tonumber(var.ers-instance-number),          # e.g. 3302
-      50013 + (tonumber(var.ers-instance-number) * 100), # e.g. 50213
-      50014 + (tonumber(var.ers-instance-number) * 100), # e.g. 50214
-      50016 + (tonumber(var.ers-instance-number) * 100), # e.g. 50216
+      3200 + tonumber(var.app-tier[0].ers-instance-number),          # e.g. 3202
+      3300 + tonumber(var.app-tier[0].ers-instance-number),          # e.g. 3302
+      50013 + (tonumber(var.app-tier[0].ers-instance-number) * 100), # e.g. 50213
+      50014 + (tonumber(var.app-tier[0].ers-instance-number) * 100), # e.g. 50214
+      50016 + (tonumber(var.app-tier[0].ers-instance-number) * 100), # e.g. 50216
     ]
   }
 
-  # TODO: logic for generating instance number specific ports
+  # Ports used for the health probes.
+  # Where Instance Number is nn:
+  # SCS (index 0) - 620nn
+  # ERS (index 1) - 621nn
+  hp-ports = [
+    62000 + tonumber(var.app-tier[0].scs-instance-number),
+    62100 + tonumber(var.app-tier[0].ers-instance-number)
+  ]
 }

--- a/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
+++ b/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
@@ -32,7 +32,7 @@ resource "azurerm_network_security_group" "nsg-db" {
 
 # Creates SAP app subnet nsg
 resource "azurerm_network_security_group" "nsg-app" {
-  count               = var.is_single_node_hana ? 0 : lookup(var.infrastructure.sap, "subnet_app.nsg.is_existing", false) ? 0 : 1
+  count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.sap.subnet_app.nsg.name
   location            = var.infrastructure.region
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
@@ -61,7 +61,7 @@ data "azurerm_network_security_group" "nsg-db" {
 
 # Imports the SAP app subnet nsg data
 data "azurerm_network_security_group" "nsg-app" {
-  count               = var.is_single_node_hana ? 0 : lookup(var.infrastructure.sap, "subnet_app.nsg.is_existing", false) ? 1 : 0
+  count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 1 : 0
   name                = split("/", var.infrastructure.vnets.sap.subnet_app.nsg.arm_id)[8]
   resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_app.nsg.arm_id)[4]
 }

--- a/deploy/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/modules/common_infrastructure/infrastructure.tf
@@ -144,7 +144,7 @@ resource "azurerm_subnet_network_security_group_association" "Associate-nsg-db" 
 
 # Associates SAP app nsg to SAP app subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-app" {
-  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (lookup(var.infrastructure.vnets.sap, "subnet_app.nsg.is_existing", false) ? 0 : 1))
+  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1))
   subnet_id                 = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
   network_security_group_id = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id
 }

--- a/deploy/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/modules/common_infrastructure/infrastructure.tf
@@ -82,7 +82,7 @@ resource "azurerm_subnet" "subnet-sap-db" {
 
 # Creates app subnet of SAP VNET
 resource "azurerm_subnet" "subnet-sap-app" {
-  count                = var.is_single_node_hana ? 0 : lookup(var.infrastructure.sap, "subnet_app.is_existing", false) ? 0 : 1
+  count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 0 : 1
   name                 = var.infrastructure.vnets.sap.subnet_app.name
   resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
   virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
@@ -115,7 +115,7 @@ data "azurerm_subnet" "subnet-sap-db" {
 
 # Imports data of existing SAP app subnet
 data "azurerm_subnet" "subnet-sap-app" {
-  count                = var.is_single_node_hana ? 0 : lookup(var.infrastructure.sap, "subnet_app.is_existing", false) ? 1 : 0
+  count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 1 : 0
   name                 = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[10]
   resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[4]
   virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[8]
@@ -144,7 +144,7 @@ resource "azurerm_subnet_network_security_group_association" "Associate-nsg-db" 
 
 # Associates SAP app nsg to SAP app subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-app" {
-  count                     = var.is_single_node_hana ? 0 : signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (lookup(var.infrastructure.sap, "subnet_app.nsg.is_existing", false) ? 0 : 1))
+  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (lookup(var.infrastructure.vnets.sap, "subnet_app.nsg.is_existing", false) ? 0 : 1))
   subnet_id                 = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
   network_security_group_id = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id
 }

--- a/deploy/terraform/modules/common_infrastructure/outputs.tf
+++ b/deploy/terraform/modules/common_infrastructure/outputs.tf
@@ -26,6 +26,14 @@ output "nsg-db" {
   value = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db : azurerm_network_security_group.nsg-db
 }
 
+output "subnet-sap-app" {
+  value = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app : azurerm_subnet.subnet-sap-app
+}
+
+output "nsg-app" {
+  value = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app : azurerm_network_security_group.nsg-app
+}
+
 output "storage-bootdiag" {
   value = azurerm_storage_account.storage-bootdiag
 }

--- a/templates/tempGen/sap-reuseVNET-SN.json
+++ b/templates/tempGen/sap-reuseVNET-SN.json
@@ -20,6 +20,9 @@
                             },
                             "subnet_db" : {
                                     "prefix" : "10.2.2.0/24"
+                            },
+                            "subnet_app" : {
+                                    "prefix" : "10.2.3.0/24"
                             }
                     }
             }

--- a/templates/tempGen/template-daily.json
+++ b/templates/tempGen/template-daily.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     }

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -44,6 +44,15 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_app": {
+          "is_existing": "false",
+          "name": "subnet-app",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-app"
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem

The current code base has no Application layer (consisting of SCS/ERS and Application VMs, and the added LB/AS etc. required).

## Description

This PR takes an initial step of adding the Application layer in an `app_tier` module. The vast majority of parameters in the Terraform configuration are hard coded to working defaults.

The Terraform added in this PR will serve as the backbone of the development for this sprint. It enables one way and one way only of deploying the application layer with a lot of hard coded defaults.

From this, Issues will be raised focusing on small improvements, which will allow for discussion and decisions about the code to be made.

## Pre-Requisites

Workstation configured to deploy into the test subscription.

## Commitment to Test

- Testing takes 1 hour
- Reviewing all files

## Test Instructions/Acceptance Criteria

### Code Review

1. Review the Template Samples, all Subnet definitions follow the existing pattern:
   - [x] [Clustered HANA](https://github.com/Centiq/sap-hana/pull/48/files#diff-8506327a33b299c3d1c98da2c29b1c33R47)
   - [x] [Clustered HANA with SBD](https://github.com/Centiq/sap-hana/pull/48/files#diff-f4255ebb55c625080674f6a83914555fR47)
   - [x] [RTI Only](https://github.com/Centiq/sap-hana/pull/48/files#diff-31ca12abd34b24b505aa851efa9e1038R47)
   - [x] [Single Node HANA](https://github.com/Centiq/sap-hana/pull/48/files#diff-2c18e02bcca40598aaf452cec22f97eeR47)
   - [x] [Single Node HANA Single Container](https://github.com/Centiq/sap-hana/pull/48/files#diff-e5ee58dfc9ebd37a45a42dec15c67ea8R47)
   - [x] [`input.json` template](https://github.com/Centiq/sap-hana/pull/48/files#diff-87e07c611a9c32b818e759bdb4b172ffR56-R66)
1. Review the Pipeline Templates, all Application subnet details follow existing patterns:
   - [x] [Main template](https://github.com/Centiq/sap-hana/pull/48/files#diff-f094462eb63a30d2ac942d5daec39a4bR47)
   - [x] [Daily template](https://github.com/Centiq/sap-hana/pull/48/files#diff-8c29f96908ec640e0405bf6717da0753R47)
   - [x] [Reuse VNet template addon](https://github.com/Centiq/sap-hana/pull/48/files#diff-f49a54216640aaf953368ce616e12ea0R23)
1. Review the initial changes to the existing common infrastructure module:
   - [x] [Application Subnet is generated with the correct variable path](https://github.com/Centiq/sap-hana/pull/48/files#diff-ef75e58f59b9bbfd1b258a282065191bR85)
   - [x] [Existing Application Subnet data is imported using the correct variable path](https://github.com/Centiq/sap-hana/pull/48/files#diff-ef75e58f59b9bbfd1b258a282065191bR118)
   - [x] [Application Subnet/NSG association uses correct variable path](https://github.com/Centiq/sap-hana/pull/48/files#diff-ef75e58f59b9bbfd1b258a282065191bR147)
   - [x] [Application NSG is generated with the correct path](https://github.com/Centiq/sap-hana/pull/48/files#diff-1cd04a5f01a866c3b657a2a4533b1688R35)
   - [x] [Existing Application NSG data is imported using the correct variable path](https://github.com/Centiq/sap-hana/pull/48/files#diff-1cd04a5f01a866c3b657a2a4533b1688R64)
   - [x] In the above links, Application Subnet and NSG generation are not tied to the `is_single_node_hana` flag
1. Review the [`app_tier` Global Variables file](https://github.com/Centiq/sap-hana/pull/48/files#diff-00a1abe6be6a78a77e594d6468a9b904R1-R7)
   - [x] Matches all other global variables files
1. Review the `app_tier` Local variables file:
   - [x] [Resource Group variable is declared with a reasonable description](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R1-R3)
   - [x] [Application Subnet variable is declared with a reasonable description](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R5-R7)
   - [x] [Application NSG variable is declared with a reasonable description](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R9-R11)
   - [x] [Application Tier object is declared with a reasonable description and default instance numbers for SCS and ERS](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R13-R19)
   - [x] [Storage device for boot diagnostics variable is declared with a reasonable description](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R
   - [x] [SID is extracted from the HANA Database description](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R27-R32)
   - [x] [SCS Load Balancer ports are calculated based on the SCS instance number](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R36-R44)
   - [x] [ERS Load Balancer ports are calculated based on the ERS instance number](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R46-R52)
   - [x] [Health Probe ports are generated using SCS and ERS instance numbers](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R55-R62)
1. Review the SCS VM TF file:
   - [x] [VM NICs are generated with sensible default names](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR1-R15)
   - [x] [VM NICs use IP addresses `10.1.3.10` and `10.1.3.11` based on the count](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR12)
   - [x] [VM NICs are associated with the Application NSG passed in to the module](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR17-R22)
   - [x] [One Load Balancer resource is generated with a sensible default name](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR25-R29)
   - [x] [The SCS Frontend IP is generated with a sensible name and using the IP `10.1.3.5`](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR31-R36)
   - [x] [The ERS Frontend IP is generated with a sensible name and using the IP `10.1.3.6`](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR39-R44)
   - [x] [A TODO note for generating the ERS Frontend IP only in HA scenarios exists](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR38)
   - [x] [One Backend Pool is created for he SCS Load Balancer](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR47-R52)
   - [x] [All generated VM NICs are associated with the Backend Pool](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR95-R101)
   - [x] [2 Health Probes are generated](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR54-R63)
   - [x] [Health Probe name depends on the index, 0 for SCS, 1 for ERS](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR54-R63)
   - [x] [Health Probe ports](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR54-R63) refer to the [generated local HP port variable with the correct index](https://github.com/Centiq/sap-hana/pull/48/files#diff-6cdfef3730721bb9a457716a667c0c77R55-R62)
   - [x] [SCS Load Balancer Ports are generated with a sensible name](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR65-R78)
   - [x] [SCS Load Balancer Ports](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR67) refer to the [Generated SCS port list]()
   - [x] [SCS Load Balancer Ports use the correct Frontend IP name](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR74)
   - [x] [SCS Load Balancer Ports use the correct Backend Pool](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR75)
   - [x] [SCS Load Balancer Ports use the correct Health Probe (`0`)](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR76)
   - [x] [SCS Load Balancer Ports have Floating IP enabled](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR77)
   - [x] [ERS Load Balancer Ports are generated with a sensible name](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR18-R93)
   - [x] [ERS Load Balancer Ports](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR82) refer to the [Generated SCS port list]()
   - [x] [ERS Load Balancer Ports use the correct Frontend IP name](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR89)
   - [x] [ERS Load Balancer Ports use the correct Backend Pool](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR90)
   - [x] [ERS Load Balancer Ports use the correct Health Probe (`1)`](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR91)
   - [x] [ERS Load Balancer Ports have Floating IP enabled](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR92)
   - [x] [ERS Load Balancer Ports have a TODO note to generate only in HA scenarios](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR80)
   - [x] [Availability Set is generated with a sensible name](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR104-R112)
   - [x] [Two SCS VMs are generated](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR104-R112)
   - [x] [`name` and `computer_name` generated default is sensible and matches](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR117-R118)
   - [x] [SCS VMs are added to the Availability Set](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR121)
   - [x] [NIC is added to the VM](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR122-R124)
   - [x] [Sensible default size (to be discussed) chosen for VMs](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR125)
   - [x] [Sensible values for admin username/password are chosen, with password authentication disabled](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR126-R128)
     _Note: values used as placeholders for parameterising._
   - [x] [OS Disk named sensibly](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR130-R134)
   - [x] [SLES image used as default](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR136-R141)
   - [x] [SSH access provided](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR143-R146)
   - [x] [Boot diagnostics configured for VMs](https://github.com/Centiq/sap-hana/pull/48/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR148-R151)
1. Review the Application VM TF file:
   - [x] [VM NICs are generated with sensible default names](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R1-R15)
   - [x] [VM NICs use IP addresses `10.1.3.20` and `10.1.3.21` based on the count](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R12)
   - [x] [VM NICs are associated with the Application NSG passed in to the module](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R17-R22)
   - [x] [Availability Set is generated with a sensible name](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R25-R34)
   - [x] [Two Application VMs are generated](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R37-R73)
   - [x] [`name` and `computer_name` generated default is sensible, uses the count, and matches](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R39-R40)
   - [x] [Application VMs are added to the Availability Set](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R43)
   - [x] [NIC is added to the VM](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R44-R46)
   - [x] [Sensible default size (to be discussed) chosen for VMs](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R47)
   - [x] [Sensible values for admin username/password are chosen, with password authentication disabled](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R48-R50)
     _Note: values used as placeholders for parameterising._
   - [x] [OS Disk named sensibly](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R53)
   - [x] [SLES image used as default](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R58-R63)
   - [x] [SSH access provided](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R65-R68)
   - [x] [Boot diagnostics configured for VMs](https://github.com/Centiq/sap-hana/pull/48/files#diff-1e733d3d2860b994aa9e9761363a5e69R70-R72)

:hand: Note the IP and Username for connecting to the RTI for connection tests later.

### Code Testing

This test assumes the `single_node_hana` template has not yet been modified, and as such the default SID value is used

1. Configure the Resource Group:\
   `util/set_resource_group.sh "<initials>-test-rg" "single_node_hana"`
1. Configure the SAP Download Credentials:\
   `util/set_sap_download_credentials.sh "<username>" "<password> "single_node_hana"`
1. Initialise Terraform:\
   `util/terraform_v2.sh init`
1. Plan the Terraform:\
   `util/terraform_v2.sh plan single_node_hana`
   - [x] Plan completes successfully
1. Apply the Terraform:\
   `util/terraform_v2.sh apply single_node_hana`
   - [x] Apply completes successfully
1. Inspect the Resource Group created in the [Azure Portal](https://portal.azure.com)
   - [x] Two Application VMs are created named `app0-HN1-vm` and `app1-HN1-vm`
   - [x] Each VM has an OS Disk created for it
   - [x] Application Availability Set is created
   - [x] Both VMs are in the Availability Set
   - [x] Two Application NICs are created named `app0-HN1-nic` and `app1-HN1-nic` with the IPs `10.1.3.20` and `10.1.3.21` respectively
   - [x] Two SCS VMs are created named `scs0-HN1-vm` and `scs1-HN1-vm`
   - [x] Each VM has an OS Disk created for it
   - [x] SCS Availability Set is created
   - [x] Both VMs are in the Availability Set
   - [x] Two SCS NICs are created named `scs0-HN1-nic` and `scs1-HN1-nic` with the IPs `10.1.3.10` and `10.1.3.11` respectively
   - [x] An SCS Load Balancer is created called `scs-HN1-lb`
   - [x] The Load Balancer has two Frontend IPs called `scs-HN1-lb-feip` and `ers-HN1-lb-feip` with the ips `10.1.3.5` and `10.1.3.6` respectively
   - [x] Both SCS VMs are in a Backend Address Pool named `scs-HN1-lb-bep`
   - [x] Two Health Probes are created named `scs-HN1-lb-hp` and `ers-HN1-lb-hp` with the ports `62001` and `62102` respectively
   - [x] 7 rules are associated with `scs-HN1-lb-hp` and `scs-HN1-lb-feip`:
     - `SCS_HN1_3201`
     - `SCS_HN1_3601`
     - `SCS_HN1_3901`
     - `SCS_HN1_8101`
     - `SCS_HN1_50113`
     - `SCS_HN1_50114`
     - `SCS_HN1_50116`
   - [x] 5 rules are associated with `ers-HN1-lb-hp` and `ers-HN1-lb-feip`:
     - `ERS_HN1_3202`
     - `ERS_HN1_3302`
     - `ERS_HN1_50213`
     - `ERS_HN1_50214`
     - `ERS_HN1_50216`

### Connection Tests

1. Connect to the RTI using the values output from the Terraform Apply, e.g.\
   `ssh azureadm@<IP_ADDRESS>`
1. From the RTI, test SSH to the Application and SCS VMs:
   - [x] `ssh appadmin@10.1.3.20`
   - [x] `ssh appadmin@10.1.3.21`
   - [x] `ssh scsadmin@10.1.3.10`
   - [x] `ssh scsadmin@10.1.3.11`

## References

<!-- List any references the reviewer might find useful. -->
<!-- This could include documentation for a tool, stack overflow solutions to issues etc. -->
<!-- Delete section if not required.-->
