### PR TITLE
Move Subnet/NSG creation from Common Infrastructure to relevant module

### DIFF
--- a/deploy/terraform/module.tf
+++ b/deploy/terraform/module.tf
@@ -41,10 +41,7 @@ module "hdb_node" {
   ssh-timeout      = var.ssh-timeout
   sshkey           = var.sshkey
   resource-group   = module.common_infrastructure.resource-group
-  subnet-sap-admin = module.common_infrastructure.subnet-sap-admin
-  nsg-admin        = module.common_infrastructure.nsg-admin
-  subnet-sap-db    = module.common_infrastructure.subnet-sap-db
-  nsg-db           = module.common_infrastructure.nsg-db
+  vnet-sap         = module.common_infrastructure.vnet-sap
   storage-bootdiag = module.common_infrastructure.storage-bootdiag
 }
 

--- a/deploy/terraform/module.tf
+++ b/deploy/terraform/module.tf
@@ -59,8 +59,7 @@ module "app_tier" {
   ssh-timeout      = var.ssh-timeout
   sshkey           = var.sshkey
   resource-group   = module.common_infrastructure.resource-group
-  subnet-app       = module.common_infrastructure.subnet-sap-app
-  nsg-app          = module.common_infrastructure.nsg-app
+  vnet-sap         = module.common_infrastructure.vnet-sap
   storage-bootdiag = module.common_infrastructure.storage-bootdiag
 }
 

--- a/deploy/terraform/modules/app_tier/app-vm.tf
+++ b/deploy/terraform/modules/app_tier/app-vm.tf
@@ -8,7 +8,7 @@ resource "azurerm_network_interface" "nics-app" {
 
   ip_configuration {
     name                          = "app${count.index}-${local.sid}-nic-ip"
-    subnet_id                     = var.subnet-app[0].id
+    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address            = "10.1.3.2${count.index}"
     private_ip_address_allocation = "static"
   }
@@ -18,7 +18,7 @@ resource "azurerm_network_interface" "nics-app" {
 resource "azurerm_network_interface_security_group_association" "nic-app-nsg" {
   count                     = 2
   network_interface_id      = azurerm_network_interface.nics-app[count.index].id
-  network_security_group_id = var.nsg-app[0].id
+  network_security_group_id = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id
 }
 
 

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -1,2 +1,38 @@
-# TODO: SubNet
-# TODO: NSG
+# Creates app subnet of SAP VNET
+resource "azurerm_subnet" "subnet-sap-app" {
+  count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 0 : 1
+  name                 = var.infrastructure.vnets.sap.subnet_app.name
+  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
+  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  address_prefixes     = [var.infrastructure.vnets.sap.subnet_app.prefix]
+}
+
+# Imports data of existing SAP app subnet
+data "azurerm_subnet" "subnet-sap-app" {
+  count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 1 : 0
+  name                 = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[10]
+  resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[4]
+  virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[8]
+}
+
+# Creates SAP app subnet nsg
+resource "azurerm_network_security_group" "nsg-app" {
+  count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1
+  name                = var.infrastructure.vnets.sap.subnet_app.nsg.name
+  location            = var.infrastructure.region
+  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+}
+
+# Imports the SAP app subnet nsg data
+data "azurerm_network_security_group" "nsg-app" {
+  count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 1 : 0
+  name                = split("/", var.infrastructure.vnets.sap.subnet_app.nsg.arm_id)[8]
+  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_app.nsg.arm_id)[4]
+}
+
+# Associates SAP app nsg to SAP app subnet
+resource "azurerm_subnet_network_security_group_association" "Associate-nsg-app" {
+  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1))
+  subnet_id                 = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+  network_security_group_id = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id
+}

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -2,8 +2,8 @@
 resource "azurerm_subnet" "subnet-sap-app" {
   count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 0 : 1
   name                 = var.infrastructure.vnets.sap.subnet_app.name
-  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
-  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  resource_group_name  = var.vnet-sap[0].resource_group_name
+  virtual_network_name = var.vnet-sap[0].name
   address_prefixes     = [var.infrastructure.vnets.sap.subnet_app.prefix]
 }
 
@@ -20,7 +20,7 @@ resource "azurerm_network_security_group" "nsg-app" {
   count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.sap.subnet_app.nsg.name
   location            = var.infrastructure.region
-  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
 }
 
 # Imports the SAP app subnet nsg data

--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -8,7 +8,7 @@ resource "azurerm_network_interface" "nics-scs" {
 
   ip_configuration {
     name                          = "scs-${local.sid}-nic-${count.index}-ip"
-    subnet_id                     = var.subnet-app[0].id
+    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address            = "10.1.3.1${count.index}"
     private_ip_address_allocation = "static"
   }
@@ -18,7 +18,7 @@ resource "azurerm_network_interface" "nics-scs" {
 resource "azurerm_network_interface_security_group_association" "nic-scs-nsg" {
   count                     = 2
   network_interface_id      = azurerm_network_interface.nics-scs[count.index].id
-  network_security_group_id = var.nsg-app[0].id
+  network_security_group_id = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id
 }
 
 # Create the SCS Load Balancer
@@ -30,7 +30,7 @@ resource "azurerm_lb" "scs-lb" {
 
   frontend_ip_configuration {
     name                          = "scs-${local.sid}-lb-feip"
-    subnet_id                     = var.subnet-app[0].id
+    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
     private_ip_address            = "10.1.3.5"
   }
@@ -38,7 +38,7 @@ resource "azurerm_lb" "scs-lb" {
   # TODO: Base this on the HA parameter
   frontend_ip_configuration {
     name                          = "ers-${local.sid}-lb-feip"
-    subnet_id                     = var.subnet-app[0].id
+    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
     private_ip_address            = "10.1.3.6"
   }

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -2,12 +2,8 @@ variable "resource-group" {
   description = "Details of the resource group"
 }
 
-variable "subnet-app" {
-  description = "Details of the SAP Application subnet"
-}
-
-variable "nsg-app" {
-  description = "Details of the SAP Application subnet NSG"
+variable "vnet-sap" {
+  description = "Details of the SAP VNet"
 }
 
 variable "app-tier" {

--- a/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
+++ b/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
@@ -30,14 +30,6 @@ resource "azurerm_network_security_group" "nsg-db" {
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
 }
 
-# Creates SAP app subnet nsg
-resource "azurerm_network_security_group" "nsg-app" {
-  count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1
-  name                = var.infrastructure.vnets.sap.subnet_app.nsg.name
-  location            = var.infrastructure.region
-  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-}
-
 # Imports the mgmt subnet nsg data
 data "azurerm_network_security_group" "nsg-mgmt" {
   count               = var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? 1 : 0
@@ -57,11 +49,4 @@ data "azurerm_network_security_group" "nsg-db" {
   count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 1 : 0
   name                = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[8]
   resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[4]
-}
-
-# Imports the SAP app subnet nsg data
-data "azurerm_network_security_group" "nsg-app" {
-  count               = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 1 : 0
-  name                = split("/", var.infrastructure.vnets.sap.subnet_app.nsg.arm_id)[8]
-  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_app.nsg.arm_id)[4]
 }

--- a/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
+++ b/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
@@ -14,39 +14,9 @@ resource "azurerm_network_security_group" "nsg-mgmt" {
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
 }
 
-# Creates SAP admin subnet nsg
-resource "azurerm_network_security_group" "nsg-admin" {
-  count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1
-  name                = var.infrastructure.vnets.sap.subnet_admin.nsg.name
-  location            = var.infrastructure.region
-  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-}
-
-# Creates SAP db subnet nsg
-resource "azurerm_network_security_group" "nsg-db" {
-  count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
-  name                = var.infrastructure.vnets.sap.subnet_db.nsg.name
-  location            = var.infrastructure.region
-  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-}
-
 # Imports the mgmt subnet nsg data
 data "azurerm_network_security_group" "nsg-mgmt" {
   count               = var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? 1 : 0
   name                = split("/", var.infrastructure.vnets.management.subnet_mgmt.nsg.arm_id)[8]
   resource_group_name = split("/", var.infrastructure.vnets.management.subnet_mgmt.nsg.arm_id)[4]
-}
-
-# Imports the SAP admin subnet nsg data
-data "azurerm_network_security_group" "nsg-admin" {
-  count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 1 : 0
-  name                = split("/", var.infrastructure.vnets.sap.subnet_admin.nsg.arm_id)[8]
-  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_admin.nsg.arm_id)[4]
-}
-
-# Imports the SAP db subnet nsg data
-data "azurerm_network_security_group" "nsg-db" {
-  count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 1 : 0
-  name                = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[8]
-  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[4]
 }

--- a/deploy/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/modules/common_infrastructure/infrastructure.tf
@@ -62,24 +62,6 @@ resource "azurerm_subnet" "subnet-mgmt" {
   address_prefixes     = [var.infrastructure.vnets.management.subnet_mgmt.prefix]
 }
 
-# Creates admin subnet of SAP VNET
-resource "azurerm_subnet" "subnet-sap-admin" {
-  count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1
-  name                 = var.infrastructure.vnets.sap.subnet_admin.name
-  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
-  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
-  address_prefixes     = [var.infrastructure.vnets.sap.subnet_admin.prefix]
-}
-
-# Creates db subnet of SAP VNET
-resource "azurerm_subnet" "subnet-sap-db" {
-  count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1
-  name                 = var.infrastructure.vnets.sap.subnet_db.name
-  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
-  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
-  address_prefixes     = [var.infrastructure.vnets.sap.subnet_db.prefix]
-}
-
 # Imports data of existing mgmt subnet
 data "azurerm_subnet" "subnet-mgmt" {
   count                = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? 1 : 0
@@ -88,41 +70,11 @@ data "azurerm_subnet" "subnet-mgmt" {
   virtual_network_name = split("/", var.infrastructure.vnets.management.subnet_mgmt.arm_id)[8]
 }
 
-# Imports data of existing SAP admin subnet
-data "azurerm_subnet" "subnet-sap-admin" {
-  count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 1 : 0
-  name                 = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[10]
-  resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[4]
-  virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[8]
-}
-
-# Imports data of existing SAP db subnet
-data "azurerm_subnet" "subnet-sap-db" {
-  count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 1 : 0
-  name                 = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[10]
-  resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[4]
-  virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[8]
-}
-
 # Associates mgmt nsg to mgmt subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-mgmt" {
   count                     = signum((var.infrastructure.vnets.management.is_existing ? 0 : 1) + (var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? 0 : 1))
   subnet_id                 = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? data.azurerm_subnet.subnet-mgmt[0].id : azurerm_subnet.subnet-mgmt[0].id
   network_security_group_id = var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? data.azurerm_network_security_group.nsg-mgmt[0].id : azurerm_network_security_group.nsg-mgmt[0].id
-}
-
-# Associates SAP admin nsg to SAP admin subnet
-resource "azurerm_subnet_network_security_group_association" "Associate-nsg-admin" {
-  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1))
-  subnet_id                 = var.infrastructure.vnets.sap.subnet_admin.is_existing ? data.azurerm_subnet.subnet-sap-admin[0].id : azurerm_subnet.subnet-sap-admin[0].id
-  network_security_group_id = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].id : azurerm_network_security_group.nsg-admin[0].id
-}
-
-# Associates SAP db nsg to SAP db subnet
-resource "azurerm_subnet_network_security_group_association" "Associate-nsg-db" {
-  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1))
-  subnet_id                 = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
-  network_security_group_id = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].id : azurerm_network_security_group.nsg-db[0].id
 }
 
 # VNET PEERINGs ==================================================================================================

--- a/deploy/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/modules/common_infrastructure/infrastructure.tf
@@ -80,15 +80,6 @@ resource "azurerm_subnet" "subnet-sap-db" {
   address_prefixes     = [var.infrastructure.vnets.sap.subnet_db.prefix]
 }
 
-# Creates app subnet of SAP VNET
-resource "azurerm_subnet" "subnet-sap-app" {
-  count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 0 : 1
-  name                 = var.infrastructure.vnets.sap.subnet_app.name
-  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
-  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
-  address_prefixes     = [var.infrastructure.vnets.sap.subnet_app.prefix]
-}
-
 # Imports data of existing mgmt subnet
 data "azurerm_subnet" "subnet-mgmt" {
   count                = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? 1 : 0
@@ -113,14 +104,6 @@ data "azurerm_subnet" "subnet-sap-db" {
   virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[8]
 }
 
-# Imports data of existing SAP app subnet
-data "azurerm_subnet" "subnet-sap-app" {
-  count                = var.infrastructure.vnets.sap.subnet_app.is_existing ? 1 : 0
-  name                 = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[10]
-  resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[4]
-  virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_app.arm_id)[8]
-}
-
 # Associates mgmt nsg to mgmt subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-mgmt" {
   count                     = signum((var.infrastructure.vnets.management.is_existing ? 0 : 1) + (var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? 0 : 1))
@@ -140,13 +123,6 @@ resource "azurerm_subnet_network_security_group_association" "Associate-nsg-db" 
   count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1))
   subnet_id                 = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
   network_security_group_id = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].id : azurerm_network_security_group.nsg-db[0].id
-}
-
-# Associates SAP app nsg to SAP app subnet
-resource "azurerm_subnet_network_security_group_association" "Associate-nsg-app" {
-  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1))
-  subnet_id                 = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
-  network_security_group_id = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id
 }
 
 # VNET PEERINGs ==================================================================================================

--- a/deploy/terraform/modules/common_infrastructure/outputs.tf
+++ b/deploy/terraform/modules/common_infrastructure/outputs.tf
@@ -2,6 +2,10 @@ output "resource-group" {
   value = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group : azurerm_resource_group.resource-group
 }
 
+output "vnet-sap" {
+  value = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap : azurerm_virtual_network.vnet-sap
+}
+
 output "subnet-mgmt" {
   value = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? data.azurerm_subnet.subnet-mgmt : azurerm_subnet.subnet-mgmt
 }
@@ -24,14 +28,6 @@ output "subnet-sap-db" {
 
 output "nsg-db" {
   value = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db : azurerm_network_security_group.nsg-db
-}
-
-output "subnet-sap-app" {
-  value = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app : azurerm_subnet.subnet-sap-app
-}
-
-output "nsg-app" {
-  value = var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? data.azurerm_network_security_group.nsg-app : azurerm_network_security_group.nsg-app
 }
 
 output "storage-bootdiag" {

--- a/deploy/terraform/modules/common_infrastructure/outputs.tf
+++ b/deploy/terraform/modules/common_infrastructure/outputs.tf
@@ -14,22 +14,6 @@ output "nsg-mgmt" {
   value = var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? data.azurerm_network_security_group.nsg-mgmt : azurerm_network_security_group.nsg-mgmt
 }
 
-output "subnet-sap-admin" {
-  value = var.infrastructure.vnets.sap.subnet_admin.is_existing ? data.azurerm_subnet.subnet-sap-admin : azurerm_subnet.subnet-sap-admin
-}
-
-output "nsg-admin" {
-  value = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin : azurerm_network_security_group.nsg-admin
-}
-
-output "subnet-sap-db" {
-  value = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db : azurerm_subnet.subnet-sap-db
-}
-
-output "nsg-db" {
-  value = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db : azurerm_network_security_group.nsg-db
-}
-
 output "storage-bootdiag" {
   value = azurerm_storage_account.storage-bootdiag
 }

--- a/deploy/terraform/modules/hdb_node/hdb-nsg.tf
+++ b/deploy/terraform/modules/hdb_node/hdb-nsg.tf
@@ -8,8 +8,8 @@
 resource "azurerm_network_security_rule" "nsr-db" {
   count                       = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1
   name                        = "deny-inbound-traffic"
-  resource_group_name         = var.nsg-db[0].resource_group_name
-  network_security_group_name = var.nsg-db[0].name
+  resource_group_name         = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].resource_group_name : azurerm_network_security_group.nsg-db[0].resource_group_name
+  network_security_group_name = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].name : azurerm_network_security_group.nsg-db[0].name
   priority                    = 102
   direction                   = "Inbound"
   access                      = "deny"
@@ -24,8 +24,8 @@ resource "azurerm_network_security_rule" "nsr-db" {
 resource "azurerm_network_security_rule" "nsr-admin" {
   count                       = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
   name                        = "nsr-subnet-db"
-  resource_group_name         = var.nsg-admin[0].resource_group_name
-  network_security_group_name = var.nsg-admin[0].name
+  resource_group_name         = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].resource_group_name : azurerm_network_security_group.nsg-admin[0].resource_group_name
+  network_security_group_name = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].name : azurerm_network_security_group.nsg-admin[0].name
   priority                    = 102
   direction                   = "Inbound"
   access                      = "allow"

--- a/deploy/terraform/modules/hdb_node/infrastructure.tf
+++ b/deploy/terraform/modules/hdb_node/infrastructure.tf
@@ -1,0 +1,77 @@
+# Creates admin subnet of SAP VNET
+resource "azurerm_subnet" "subnet-sap-admin" {
+  count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1
+  name                 = var.infrastructure.vnets.sap.subnet_admin.name
+  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
+  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  address_prefixes     = [var.infrastructure.vnets.sap.subnet_admin.prefix]
+}
+
+# Creates db subnet of SAP VNET
+resource "azurerm_subnet" "subnet-sap-db" {
+  count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1
+  name                 = var.infrastructure.vnets.sap.subnet_db.name
+  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
+  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  address_prefixes     = [var.infrastructure.vnets.sap.subnet_db.prefix]
+}
+
+# Imports data of existing SAP admin subnet
+data "azurerm_subnet" "subnet-sap-admin" {
+  count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 1 : 0
+  name                 = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[10]
+  resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[4]
+  virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[8]
+}
+
+# Imports data of existing SAP db subnet
+data "azurerm_subnet" "subnet-sap-db" {
+  count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 1 : 0
+  name                 = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[10]
+  resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[4]
+  virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[8]
+}
+
+# Creates SAP admin subnet nsg
+resource "azurerm_network_security_group" "nsg-admin" {
+  count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1
+  name                = var.infrastructure.vnets.sap.subnet_admin.nsg.name
+  location            = var.infrastructure.region
+  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+}
+
+# Creates SAP db subnet nsg
+resource "azurerm_network_security_group" "nsg-db" {
+  count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
+  name                = var.infrastructure.vnets.sap.subnet_db.nsg.name
+  location            = var.infrastructure.region
+  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+}
+
+# Imports the SAP admin subnet nsg data
+data "azurerm_network_security_group" "nsg-admin" {
+  count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 1 : 0
+  name                = split("/", var.infrastructure.vnets.sap.subnet_admin.nsg.arm_id)[8]
+  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_admin.nsg.arm_id)[4]
+}
+
+# Imports the SAP db subnet nsg data
+data "azurerm_network_security_group" "nsg-db" {
+  count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 1 : 0
+  name                = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[8]
+  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[4]
+}
+
+# Associates SAP admin nsg to SAP admin subnet
+resource "azurerm_subnet_network_security_group_association" "Associate-nsg-admin" {
+  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1))
+  subnet_id                 = var.infrastructure.vnets.sap.subnet_admin.is_existing ? data.azurerm_subnet.subnet-sap-admin[0].id : azurerm_subnet.subnet-sap-admin[0].id
+  network_security_group_id = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].id : azurerm_network_security_group.nsg-admin[0].id
+}
+
+# Associates SAP db nsg to SAP db subnet
+resource "azurerm_subnet_network_security_group_association" "Associate-nsg-db" {
+  count                     = signum((var.infrastructure.vnets.sap.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1))
+  subnet_id                 = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
+  network_security_group_id = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].id : azurerm_network_security_group.nsg-db[0].id
+}

--- a/deploy/terraform/modules/hdb_node/infrastructure.tf
+++ b/deploy/terraform/modules/hdb_node/infrastructure.tf
@@ -2,8 +2,8 @@
 resource "azurerm_subnet" "subnet-sap-admin" {
   count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1
   name                 = var.infrastructure.vnets.sap.subnet_admin.name
-  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
-  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  resource_group_name  = var.vnet-sap[0].resource_group_name
+  virtual_network_name = var.vnet-sap[0].name
   address_prefixes     = [var.infrastructure.vnets.sap.subnet_admin.prefix]
 }
 
@@ -11,8 +11,8 @@ resource "azurerm_subnet" "subnet-sap-admin" {
 resource "azurerm_subnet" "subnet-sap-db" {
   count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1
   name                 = var.infrastructure.vnets.sap.subnet_db.name
-  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
-  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  resource_group_name  = var.vnet-sap[0].resource_group_name
+  virtual_network_name = var.vnet-sap[0].name
   address_prefixes     = [var.infrastructure.vnets.sap.subnet_db.prefix]
 }
 
@@ -37,7 +37,7 @@ resource "azurerm_network_security_group" "nsg-admin" {
   count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.sap.subnet_admin.nsg.name
   location            = var.infrastructure.region
-  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
 }
 
 # Creates SAP db subnet nsg
@@ -45,7 +45,7 @@ resource "azurerm_network_security_group" "nsg-db" {
   count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.sap.subnet_db.nsg.name
   location            = var.infrastructure.region
-  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
 }
 
 # Imports the SAP admin subnet nsg data

--- a/deploy/terraform/modules/hdb_node/variables_local.tf
+++ b/deploy/terraform/modules/hdb_node/variables_local.tf
@@ -2,20 +2,8 @@ variable "resource-group" {
   description = "Details of the resource group"
 }
 
-variable "subnet-sap-admin" {
-  description = "Details of the SAP admin subnet"
-}
-
-variable "subnet-sap-db" {
-  description = "Details of the SAP DB subnet"
-}
-
-variable "nsg-admin" {
-  description = "Details of the SAP admin subnet NSG"
-}
-
-variable "nsg-db" {
-  description = "Details of the SAP DB subnet NSG"
+variable "vnet-sap" {
+  description = "Details of the SAP VNet"
 }
 
 variable "storage-bootdiag" {


### PR DESCRIPTION
## Problem

The end goal is to have the resources specific to the HDB or Application layers deployed only when that particular layer is deployed.  At present the subnets and NSGs for the HDB module and the application tier are both deployed in the `common_infrastructure` module.

## Description

This PR moves the Application subnet and NSG to the `app_tier` module, and the `admin` and `db` subnets/NSGs to the HDB module.

_**Note:** This PR is based off of the branch in Azure/sap-hana#515_

## Pre-Requisites

Knowledge of Terraform

## Commitment to Test

- Testing takes 30 minutes
- Reviewing 12 files

## Test Instructions/Acceptance Criteria

### Deployment Testing

This has been listed first as the deployment can take upwards of 10 minutes to complete. While waiting to check the eventual result, the Code Review notes below can be looked at.

1. Ensure the Terraform modules have been initialised:\
   `util/terraform_v2.sh init`
1. Ensure the SAP download credentials have been set:\
   `util/set_sap_download_credentials.sh "<username>" "<password>" "single_node_hana"`
1. Plan the deployment:\
   `util/terraform_v2.sh plan "single_node_hana"`
   - [ ] Plan completes successfully without error
1. Apply the deployment plan:\
   `util/terraform_v2.sh apply "single_node_hana"`
   - [ ] Deployment completes successfully.
     :hand: Deployments may fail due to ARM issues in Azure, check the [Azure Status page](https://status.azure.com/en-gb/status) if deployment fails

### Code Review 

1. The Common Infrastructure module:
   - [ ] [No longer creates the Admin, DB, or App NSGs](https://github.com/Centiq/sap-hana/pull/49/files#diff-1cd04a5f01a866c3b657a2a4533b1688L17-L40)
   - [ ] [No longer imports the Admin, DB, or App NSG data if it already exists](https://github.com/Centiq/sap-hana/pull/49/files#diff-1cd04a5f01a866c3b657a2a4533b1688L47-L67)
   - [ ] [No longer creates the Admin, DB, or App Subnets](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef75e58f59b9bbfd1b258a282065191bL65-L91)
   - [ ] [No longer imports the Admin, DB, or App Subnet data if it already exists](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef75e58f59b9bbfd1b258a282065191bL100-L123)
   - [ ] [No longer associates the Admin, DB, or App Subnets and NSGs](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef75e58f59b9bbfd1b258a282065191bL131-L151)
   - [ ] [Exports the SAP VNet](https://github.com/Centiq/sap-hana/pull/49/files#diff-69c76866c9114d092be1bf70a0febc0eR5-R8)
   - [ ] [No longer exports the Admin, DB, or App subnets and NSGs](https://github.com/Centiq/sap-hana/pull/49/files#diff-69c76866c9114d092be1bf70a0febc0eL13-L36)
1. The Application Tier module:
   - [ ] [Accepts the VNet instead of the subnet and NSG](https://github.com/Centiq/sap-hana/pull/49/files#diff-6cdfef3730721bb9a457716a667c0c77L5-R6)
   - [ ] [Creates the App Subnet and NSG](https://github.com/Centiq/sap-hana/pull/49/files#diff-6258184e402b30d09a005c404fe9d72aR1-R38)
   - [ ] Uses the passed in VNet details for:
     - [ ] The [App subnet](https://github.com/Centiq/sap-hana/pull/49/files#diff-6258184e402b30d09a005c404fe9d72aR5-R6)
     - [ ] The [App NSG](https://github.com/Centiq/sap-hana/pull/49/files#diff-6258184e402b30d09a005c404fe9d72aR23)
  - [ ] [Uses imported data if the Subnet/NSG already exists, otherwise generated](https://github.com/Centiq/sap-hana/pull/49/files#diff-e2d161cdc955d1fa4ec5b42040f1ee6cR11-R41)
1. The HDB module:
   - [ ] [Accepts the VNet instead of the Subnets and NSGs](https://github.com/Centiq/sap-hana/pull/49/files#diff-11fac9577f9cbdab7601253f86a05af4L5-R6)
   - [ ] [Creates the Admin and DB Subnets and NSGs](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef86ea17563ea311f58beee9cd07c176R1-R77)
   - [ ] Uses the passed in VNet details for:
     - [ ] The [Admin subnet](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef86ea17563ea311f58beee9cd07c176R5-R6)
     - [ ] The [Admin NSG](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef86ea17563ea311f58beee9cd07c176R40)
     - [ ] The [DB Subnet](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef86ea17563ea311f58beee9cd07c176R14-R15)
     - [ ] The [DB NSG](https://github.com/Centiq/sap-hana/pull/49/files#diff-ef86ea17563ea311f58beee9cd07c176R48)
   - [ ] [Uses imported data if the Subnets/NSGs already exist, otherwise generated data](https://github.com/Centiq/sap-hana/pull/49/files#diff-0aa64f8d9b2c65672178cb5c29c3fe43R23-R73)
