### PR TITLE
BoM Documentation and script updates

### DIFF
--- a/documentation/ansible/system-design-deployment/app/prepare-bom.md
+++ b/documentation/ansible/system-design-deployment/app/prepare-bom.md
@@ -51,8 +51,7 @@ step|BoM Content
 [3] |version: 001
     |
 [4] |defaults:
-    |  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-    |  target_location: "/usr/sap/downloads/"
+    |  target_location: "{{ target_media_location }}/downloads"
     |
 [5] |materials:
 [6] |  dependencies:
@@ -96,8 +95,7 @@ step|BoM Content
 ### Create Defaults Section
 
 1. `[4]`: This section contains:
-   1. `archive_location`: The location to which you will upload the SAP build files. Also, the same location from which the files will be copied to the target server.
-   1. `target_location`: The folder on the target server, into which the files will be copied for installation.
+   1. `target_location`: The folder on the target server, into which the files will be copied for installation. This will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path.
 
 ### Create Materials Section
 
@@ -136,18 +134,18 @@ step|BoM Content
 
 ### Override Target Destination
 
-Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This is normally set using the `defaults -> target_location` property (see [the defaults section](#create-defaults-section)). However, you may override this on a case-by-case basis.
+Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path. You may override this on a case-by-case basis.
 
 1. For each relevant entry in the BoM `media` section, add an `override_target_location:` property with the correct target folder. For example:
 
    ```text
    - name: "Kernel Part I"
      archive: "SAPEXE_200-80004393.SAR"
-     override_target_location: "/usr/sap/install/download_basket/"
+     override_target_location: "{{ target_media_location }}/download_basket/"
 
    - name: "Kernel Part II (777)"
      archive: "SAPEXEDB_200-80004392.SAR"
-     override_target_location: "/usr/sap/install/download_basket/"
+     override_target_location: "{{ target_media_location }}/download_basket/"
    ```
 
 ### Override Target Filename

--- a/documentation/ansible/system-design-deployment/app/prepare-bom.md
+++ b/documentation/ansible/system-design-deployment/app/prepare-bom.md
@@ -134,7 +134,7 @@ step|BoM Content
 
 ### Override Target Destination
 
-Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path. You may override this on a case-by-case basis.
+Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This is normally set using the `defaults -> target_location` property (see [the defaults section](#red_circle-create-defaults-section)). However, you may override this on a case-by-case basis as shown. Overrides will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path.
 
 1. For each relevant entry in the BoM `media` section, add an `override_target_location:` property with the correct target folder. For example:
 

--- a/documentation/ansible/system-design-deployment/app/prepare-full-app-bom.md
+++ b/documentation/ansible/system-design-deployment/app/prepare-full-app-bom.md
@@ -77,8 +77,7 @@ step|BoM Content
 [3] |version: 001
     |
 [4] |defaults:
-    |  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-    |  target_location: "/usr/sap/downloads/"
+    |  target_location: "{{ target_media_location }}/downloads"
     |
 [5] |materials:
 [6] |  dependencies:
@@ -126,8 +125,7 @@ step|BoM Content
 #### Create Defaults Section
 
 1. `[4]`: This section contains:
-   1. `archive_location`: The location to which you will upload the SAP build files. Also, the same location from which the files will be copied to the target server.
-   1. `target_location`: The folder on the target server, into which the files will be copied for installation.
+   1. `target_location`: The folder on the target server, into which the files will be copied for installation. Normally, this will reference `{{ target_media_location }}` as shown, but could be an unrelated path.
 
 #### Create Materials Section
 
@@ -219,7 +217,7 @@ After downloading the stack files and Download Basket manifest `.json` file into
 
 #### Override Target Destination
 
-Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This is normally set using the `defaults -> target_location` property (see [the defaults section](#create-defaults-section)). However, you may override this on a case-by-case basis.
+Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path. You may override this on a case-by-case basis.
 
 1. For each relevant entry in the BoM `media` section, add an `override_target_location:` property with the correct target folder. For example:
 
@@ -227,12 +225,12 @@ Files downloaded or shared from the archive space will need to be extracted to t
    - name: "Kernel Part I"
      archive: "SAPEXE_200-80004393.SAR"
      sapurl: "https://softwaredownloads.sap.com/file/0020000001063232020"
-     override_target_location: "/usr/sap/install/download_basket/"
+     override_target_location: "{{ target_media_location }}/download_basket/"
 
    - name: "Kernel Part II (777)"
      archive: "SAPEXEDB_200-80004392.SAR"
      sapurl: "https://softwaredownloads.sap.com/file/0020000001063182020"
-     override_target_location: "/usr/sap/install/download_basket/"
+     override_target_location: "{{ target_media_location }}/download_basket/"
    ```
 
 #### Override Target Filename

--- a/documentation/ansible/system-design-deployment/app/prepare-full-app-bom.md
+++ b/documentation/ansible/system-design-deployment/app/prepare-full-app-bom.md
@@ -217,7 +217,7 @@ After downloading the stack files and Download Basket manifest `.json` file into
 
 #### Override Target Destination
 
-Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path. You may override this on a case-by-case basis.
+Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This is normally set using the `defaults -> target_location` property (see [the defaults section](#red_circle-create-defaults-section)). However, you may override this on a case-by-case basis as shown. Overrides will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path.
 
 1. For each relevant entry in the BoM `media` section, add an `override_target_location:` property with the correct target folder. For example:
 

--- a/documentation/ansible/system-design-deployment/app/prepare-ini.md
+++ b/documentation/ansible/system-design-deployment/app/prepare-ini.md
@@ -36,22 +36,22 @@
 
    `mkdir /tmp/app_template/`
 
-1. Ensure `/usr/sap/downloads/` exists:
+1. Ensure `/usr/sap/install/` exists:
 
-   `mkdir /usr/sap/downloads/`
+   `mkdir /usr/sap/install/`
 
-1. Using the `media` entries in the BoM file, copy the required media from `sapbits` to `/usr/sap/downloads`:
+1. Using the `media` entries in the BoM file, copy the required media from `sapbits` to `/usr/sap/install`:
    1. For each entry in `media`:
 
-      `cp /mnt/sapbits/archive/<archive> /usr/sap/downloads`
+      `cp /mnt/sapbits/archive/<archive> /usr/sap/install`
 
       Where `<archive>` is the filename in the `archive:` property of the entry in the BoM.
 
-      For example: `cp /mnt/sapbits/archive/SAPHOSTAGENT49_49-20009394.SAR /usr/sap/downloads`
+      For example: `cp /mnt/sapbits/archive/SAPHOSTAGENT49_49-20009394.SAR /usr/sap/install`
 
 1. Update the permissions to make `SAPCAR` executable (SAPCAR version may change depending on your downloads):
 
-   `chmod +x /usr/sap/downloads/SAPCAR_1311-80000935.EXE`
+   `chmod +x /usr/sap/install/SAPCAR_1311-80000935.EXE`
 
 1. Ensure `/usr/sap/install/SWPM/` exists:
 
@@ -59,7 +59,7 @@
 
 1. Extract `SWPM20SP07_0-80003424.SAR` via `SAPCAR.EXE`. For example:
 
-   `/usr/sap/downloads/SAPCAR_1311-80000935.EXE -xf /usr/sap/downloads/SWPM20SP07_0-80003424.SAR -R /usr/sap/install/SWPM/`
+   `/usr/sap/install/SAPCAR_1311-80000935.EXE -xf /usr/sap/install/SWPM20SP07_0-80003424.SAR -R /usr/sap/install/SWPM/`
 
 1. Ensure `/usr/sap/install/config` exists and contains the XML Stack file downloaded from the SAP Maintenance Planner:
 
@@ -90,7 +90,7 @@ The following steps show how to begin the manual install of an ASCS instance in 
    **Note:** `The password of user DBUser may only consist of alphanumeric characters and the special characters #, $, @ and _. The first character must not be a digit or an underscore`.
 
 1. The password fields will be pre-populated based on the master password supplied. Set the `<sid>adm` OS user ID to 2000 and the `sapsys` OS group ID to 2000, and click "Next";
-1. When prompted to supply the path to the SAPEXE kernel file, specify a path of /usr/sap/downloads/ and click "Next";
+1. When prompted to supply the path to the SAPEXE kernel file, specify a path of /usr/sap/install/ and click "Next";
 1. Notice the package status is "Available" click "Next";
 1. Notice the SAP Host Agent installation file status is "Available" click "Next";
 1. Details for the sapadm OS user will be presented next. It is recommended to leave the password as inherited from the master password, and enter in the OS user ID of 2100, and click "Next";
@@ -158,7 +158,7 @@ Follow the [SAP instructions for Exporting directories via NFS for Linux](https:
 The directories to be exported for this process are:
 
 1. `/usr/sap/<SID>/SYS` - Where `<SID>` is replaced with the SID from Step 7 of the [Generating unattented installation parameter `inifile` for ASCS](#generating-unattended-installation-inifile-for-ascs)
-1. `/usr/sap/downloads`
+1. `/usr/sap/install`
 1. `/usr/sap/install/config`
 1. `/tmp/app_template`
 1. `/sapmnt/<SID>/global`
@@ -171,7 +171,7 @@ The directories to be exported for this process are:
    `mkdir -p /usr/sap/{downloads,install/config,<SID>/SYS} /tmp/app_template /sapmnt/<SID>/{global,profile}`
 
 1. Ensure the exported directories are mounted:
-   1. `mount <scs-vm-IP>:/usr/sap/downloads /usr/sap/downloads`
+   1. `mount <scs-vm-IP>:/usr/sap/install /usr/sap/install`
    1. `mount <scs-vm-IP>:/usr/sap/install/config /usr/sap/install/config`
    1. `mount <scs-vm-IP>:/usr/sap/<SID>/SYS /usr/sap/<SID>/SYS`
    1. `mount <scs-vm-IP>:/tmp/app_template /tmp/app_template`
@@ -188,7 +188,7 @@ The directories to be exported for this process are:
 
 1. Ensure SWPM is extracted:
 
-   `/usr/sap/downloads/SAPCAR_1311-80000935.EXE -xf /usr/sap/downloads/SWPM20SP07_0-80003424.SAR -R /usr/sap/install/SWPM/`
+   `/usr/sap/install/SAPCAR_1311-80000935.EXE -xf /usr/sap/install/SWPM20SP07_0-80003424.SAR -R /usr/sap/install/SWPM/`
 
 1. Launch SWPM with the following command:
 
@@ -214,7 +214,7 @@ Distributed System" , click on "Database Instance" and click "Next"
    1. click "Next"
 1. Verify the connection details and click "OK"
 1. Enter the System Database Administrator Password and click "Next"
-1. Enter the path to the SAPEXE Kernel `/usr/sap/downloads/` and click "Next"
+1. Enter the path to the SAPEXE Kernel `/usr/sap/install/` and click "Next"
 1. Notice the files are listed as available and click "Next"
 1. Notice the SAPHOSTAGENT file is listed as available and click "Next"
 1. Click "Next" on the SAP System Administrator password confirmation.
@@ -300,7 +300,7 @@ _**Note:** Steps prefixed with * may not be encountered in 2020 versions of SAP 
 1. Ensure the Profile Directory is set to `/sapmnt/<SID>/profile/` or  `/usr/sap/<SID>/SYS/profile` and click "Next"
 1. Set the Message Server Port to `36nn` where `nn` is the ASCS Instance number and click "Next"
 1. Set the Master Password for All Users and click "Next"
-1. On the Software Package Browser Screen set the Search Directory to `/usr/sap/downloads` then click "Next"
+1. On the Software Package Browser Screen set the Search Directory to `/usr/sap/install` then click "Next"
 1. ⌛️ ... wait several minutes for `below-the-fold-list` to populate then click "Next"
 1. Ensure the "Upgrade SAP Host Agent to the version of the provided SAPHOSTAGENT.SAR archive" option is unchecked then click "Next"
 1. Enter the Instance Number of the SAP HANA Database and Database System Administrator Password and click "Next"

--- a/documentation/ansible/system-design-deployment/examples/BW4HANA_2_0_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/BW4HANA_2_0_v001/bom.yml
@@ -1,17 +1,16 @@
 ---
 
-name: "BW4HANA_2_0_v001"
+name: "SAP_BW4HANA_2_0"
 target: "SAP BW/4HANA 2.0"
 version: "001"
 
 defaults:
-  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-  target_location: "/usr/sap/install/downloads/"
+  target_location: "{{ target_media_location }}/downloads/"
 
 materials:
   dependencies:
-    - name: "HANA_2_00_052_v001"
-      version: "001"
+    - name: "HANA2"
+      version: "003"
 
   media:
 
@@ -19,97 +18,92 @@ materials:
 
     - name: "Kernel Part II (777)"
       archive: "SAPEXEDB_200-80004392.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001063182020"
 
     - name: "Kernel Part I"
       archive: "SAPEXE_200-80004393.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001063232020"
 
     - name: "SAP HOST AGENT 7.21 SP49"
       archive: "SAPHOSTAGENT49_49-20009394.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001725602020"
 
     - name: "Patch 1 for SOFTWARE UPDATE MANAGER 2.0 SP09"
       archive: "SUM20SP09_1-80002456.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001781372020"
 
     - name: "SWPM20SP07"
       archive: "SWPM20SP07_1-80003424.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001765102020"
 
     - name: "Installation for SAP IGS integrated in SAP Kernel"
       archive: "igsexe_12-80003187.sar"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001632902020"
 
     - name: "SAP IGS Fonts and Textures"
       archive: "igshelper_17-10010245.sar"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000000703122018"
 
     # db export components
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_1.zip"
       archive: "BW4HANA200_INST_EXPORT_1.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365682019"
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_2.zip"
       archive: "BW4HANA200_INST_EXPORT_2.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365682019"
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_3.zip"
       archive: "BW4HANA200_INST_EXPORT_3.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365692019"
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_4.zip"
       archive: "BW4HANA200_INST_EXPORT_4.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365712019"
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_5.zip"
       archive: "BW4HANA200_INST_EXPORT_5.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365742019"
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_6.zip"
       archive: "BW4HANA200_INST_EXPORT_6.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365782019"
 
     - name: "File on DVD - BW4HANA200_INST_EXPORT_7.zip"
       archive: "BW4HANA200_INST_EXPORT_7.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365802019"
 
     - name: "File on DVD - BW4HANA200_NW_LANG_DE.SAR"
       archive: "BW4HANA200_NW_LANG_DE.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365892019"
 
     - name: "File on DVD - BW4HANA200_NW_LANG_EN.SAR"
       archive: "BW4HANA200_NW_LANG_EN.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000365932019"
 
     - name: "File on DVD - BW4HANA200_NW_LANG_UK.SAR"
       archive: "BW4HANA200_NW_LANG_UK.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000000366442019"
 
     # other components
-
-    - name:     SAPCAR
-      version:  7.21
-      archive:  SAPCAR_1320-80000935.EXE
-      override_target_filename: SAPCAR.EXE
 
     - name: "Attribute Change Package 02 for DW4CORE 200"
       archive: "DW4CORE200.SAR"
@@ -237,5 +231,5 @@ materials:
 
   templates:
 
-    - name: "BW4HANA_2_0_v001 ini file"
-      file: "BW4HANA_2_0_v001.inifile.params"
+    - name: "SAP_BW4HANA_2_0 ini file"
+      file: "SAP_BW4HANA_2_0.inifile.params"

--- a/documentation/ansible/system-design-deployment/examples/BW4HANA_2_0_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/BW4HANA_2_0_v001/bom.yml
@@ -1,7 +1,7 @@
 ---
 
-name: "S4HANA_1909_SP2_v001"
-target: "ABAP PLATFORM 1909"
+name: "SAP_BW4HANA_2_0"
+target: "SAP BW/4HANA 2.0"
 version: "001"
 
 defaults:
@@ -231,5 +231,5 @@ materials:
 
   templates:
 
-        - name: "S4HANA_1909_SP2_v001 ini file"
-          file: "S4HANA_S4HANA_1909_SP2_v001.inifile.params"
+    - name: "SAP_BW4HANA_2_0 ini file"
+      file: "SAP_BW4HANA_2_0.inifile.params"

--- a/documentation/ansible/system-design-deployment/examples/BW4HANA_2_0_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/BW4HANA_2_0_v001/bom.yml
@@ -1,7 +1,7 @@
 ---
 
-name: "SAP_BW4HANA_2_0"
-target: "SAP BW/4HANA 2.0"
+name: "S4HANA_1909_SP2_v001"
+target: "ABAP PLATFORM 1909"
 version: "001"
 
 defaults:
@@ -9,8 +9,8 @@ defaults:
 
 materials:
   dependencies:
-    - name: "HANA2"
-      version: "003"
+    - name: "HANA_2_00_052_v001"
+      version: "001"
 
   media:
 
@@ -231,5 +231,5 @@ materials:
 
   templates:
 
-    - name: "SAP_BW4HANA_2_0 ini file"
-      file: "SAP_BW4HANA_2_0.inifile.params"
+        - name: "S4HANA_1909_SP2_v001 ini file"
+          file: "S4HANA_S4HANA_1909_SP2_v001.inifile.params"

--- a/documentation/ansible/system-design-deployment/examples/HANA_1_00_122_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/HANA_1_00_122_v001/bom.yml
@@ -5,8 +5,7 @@ target:  "HANA 1.0"
 version: 001
 
 defaults:
-  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-  target_location: "/usr/sap/install/downloads/"
+  target_location: "{{ target_media_location }}/downloads/"
 
 materials:
   media:

--- a/documentation/ansible/system-design-deployment/examples/HANA_2_00_052_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/HANA_2_00_052_v001/bom.yml
@@ -5,8 +5,7 @@ target:  "HANA 2.0"
 version: 001
 
 defaults:
-  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-  target_location: "/usr/sap/install/downloads/"
+  target_location: "{{ target_media_location }}/downloads/"
 
 materials:
   media:

--- a/documentation/ansible/system-design-deployment/examples/S4HANA_1909_SP2_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/S4HANA_1909_SP2_v001/bom.yml
@@ -1,6 +1,6 @@
 ---
 
-name: "SAP_S4HANA_1909"
+name: "S4HANA_1909_SP2_v001"
 target: "ABAP PLATFORM 1909"
 version: "001"
 
@@ -9,8 +9,8 @@ defaults:
 
 materials:
   dependencies:
-    - name: "HANA2"
-      version: "003"
+    - name: "HANA_2_00_052_v001"
+      version: "001"
 
   media:
 
@@ -685,5 +685,5 @@ materials:
 
   templates:
 
-    - name: "SAP_S4HANA_1909 ini file"
-      file: "SAP_S4HANA_1909.inifile.params"
+        - name: "S4HANA_1909_SP2_v001 ini file"
+          file: "S4HANA_S4HANA_1909_SP2_v001.inifile.params"

--- a/documentation/ansible/system-design-deployment/examples/S4HANA_1909_SP2_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/S4HANA_1909_SP2_v001/bom.yml
@@ -1,17 +1,16 @@
 ---
 
-name: "S4HANA_1909_SP2_v001"
+name: "SAP_S4HANA_1909"
 target: "ABAP PLATFORM 1909"
 version: "001"
 
 defaults:
-  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-  target_location: "/usr/sap/install/downloads/"
+  target_location: "{{ target_media_location }}/downloads/"
 
 materials:
   dependencies:
-    - name: "HANA_2_00_052_v001"
-      version: "001"
+    - name: "HANA2"
+      version: "003"
 
   media:
 
@@ -19,207 +18,202 @@ materials:
 
     - name: "SP12 Patch2 for UMML4HANA 1"
       archive: "HANAUMML12_2-70001054.ZIP"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000000878972020"
 
     - name: "Kernel Part II (777)"
       archive: "SAPEXEDB_300-80004392.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001809622020"
 
     - name: "Kernel Part I"
       archive: "SAPEXE_300-80004393.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001809672020"
 
     - name: "SAP HOST AGENT 7.21 SP49"
       archive: "SAPHOSTAGENT49_49-20009394.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001725602020"
 
     - name: "Predi. Analy. APL 1907 for SAP HANA 2.0 SPS03 and beyond"
       archive: "SAPPAAPL4_1907_0-80004547.ZIP"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001399672019"
 
     - name: "Patch 1 for SOFTWARE UPDATE MANAGER 2.0 SP09"
       archive: "SUM20SP09_1-80002456.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001781372020"
 
     - name: "SWPM20SP07"
       archive: "SWPM20SP07_2-80003424.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001812632020"
 
     - name: "Installation for SAP IGS integrated in SAP Kernel"
       archive: "igsexe_12-80003187.sar"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001632902020"
 
     - name: "SAP IGS Fonts and Textures"
       archive: "igshelper_17-10010245.sar"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000000703122018"
 
     # db export components
 
     - name: "Attribute Change Package 04 for S4CORE 104"
       archive: "S4CORE104.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632802019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_1.zip"
       archive: "S4CORE104_INST_EXPORT_1.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632352019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_10.zip"
       archive: "S4CORE104_INST_EXPORT_10.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632372019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_11.zip"
       archive: "S4CORE104_INST_EXPORT_11.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632382019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_12.zip"
       archive: "S4CORE104_INST_EXPORT_12.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632402019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_13.zip"
       archive: "S4CORE104_INST_EXPORT_13.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632442019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_14.zip"
       archive: "S4CORE104_INST_EXPORT_14.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632472019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_15.zip"
       archive: "S4CORE104_INST_EXPORT_15.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632502019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_16.zip"
       archive: "S4CORE104_INST_EXPORT_16.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632562019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_17.zip"
       archive: "S4CORE104_INST_EXPORT_17.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632682019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_18.zip"
       archive: "S4CORE104_INST_EXPORT_18.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632732019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_19.zip"
       archive: "S4CORE104_INST_EXPORT_19.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632782019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_2.zip"
       archive: "S4CORE104_INST_EXPORT_2.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632802019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_20.zip"
       archive: "S4CORE104_INST_EXPORT_20.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632832019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_21.zip"
       archive: "S4CORE104_INST_EXPORT_21.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632862019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_22.zip"
       archive: "S4CORE104_INST_EXPORT_22.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632902019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_23.zip"
       archive: "S4CORE104_INST_EXPORT_23.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632932019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_24.zip"
       archive: "S4CORE104_INST_EXPORT_24.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632972019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_25.zip"
       archive: "S4CORE104_INST_EXPORT_25.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633002019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_3.zip"
       archive: "S4CORE104_INST_EXPORT_3.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633012019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_4.zip"
       archive: "S4CORE104_INST_EXPORT_4.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633032019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_5.zip"
       archive: "S4CORE104_INST_EXPORT_5.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633052019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_6.zip"
       archive: "S4CORE104_INST_EXPORT_6.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633092019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_7.zip"
       archive: "S4CORE104_INST_EXPORT_7.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633142019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_8.zip"
       archive: "S4CORE104_INST_EXPORT_8.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633192019"
 
     - name: "File on DVD - S4CORE104_INST_EXPORT_9.zip"
       archive: "S4CORE104_INST_EXPORT_9.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001633242019"
 
     - name: "File on DVD - S4HANAOP104_ERP_LANG_DE.SAR"
       archive: "S4HANAOP104_ERP_LANG_DE.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001631712019"
 
     - name: "File on DVD - S4HANAOP104_ERP_LANG_EN.SAR"
       archive: "S4HANAOP104_ERP_LANG_EN.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001631732019"
 
     - name: "Attribute Change Package 06 for SAP_UI 754"
       archive: "SAP_UI754.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632802019"
 
     - name: "Attribute Change Package 19 for SRA004 600"
       archive: "SRA004600.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001632802019"
 
     # other components
-
-    - name:     SAPCAR
-      version:  7.21
-      archive:  SAPCAR_1320-80000935.EXE
-      override_target_filename: SAPCAR.EXE
 
     - name: "Attribute Change Package 16 for EA-HR 608"
       archive: "EA-HR608.SAR"
@@ -689,7 +683,7 @@ materials:
       archive: "UITRV001300.SAR"
       sapurl: "https://softwaredownloads.sap.com/file/0010000000297212015"
 
-      templates:
+  templates:
 
-        - name: "S4HANA_1909_SP2_v001 ini file"
-          file: "S4HANA_S4HANA_1909_SP2_v001.inifile.params"
+    - name: "SAP_S4HANA_1909 ini file"
+      file: "SAP_S4HANA_1909.inifile.params"

--- a/documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom.yml
@@ -1,17 +1,16 @@
 ---
 
-name: "S4HANA_2020_ISS_v001"
+name: "SAP_S4HANA_2020"
 target: "ABAP PLATFORM 2020"
 version: "001"
 
 defaults:
-  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-  target_location: "/usr/sap/install/downloads/"
+  target_location: "{{ target_media_location }}/downloads/"
 
 materials:
   dependencies:
-    - name: "HANA_2_00_052_v001"
-      version: "001"
+    - name: "HANA2"
+      version: "003"
 
   media:
 
@@ -19,197 +18,192 @@ materials:
 
     - name: "SP12 Patch2 for UMML4HANA 1"
       archive: "HANAUMML12_2-70001054.ZIP"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000000878972020"
 
     - name: "Kernel Part II (781)"
       archive: "SAPEXEDB_19-70005282.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001753572020"
 
     - name: "Kernel Part I (781)"
       archive: "SAPEXE_19-70005283.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001753762020"
 
     - name: "SAP HOST AGENT 7.21 SP49"
       archive: "SAPHOSTAGENT49_49-20009394.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001725602020"
 
     - name: "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"
       archive: "SAPPAAPL4_2008_0-80004547.ZIP"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000000410162020"
 
     - name: "Patch 1 for SOFTWARE UPDATE MANAGER 2.0 SP09"
       archive: "SUM20SP09_1-80002456.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001781372020"
 
     - name: "SWPM20SP07"
       archive: "SWPM20SP07_2-80003424.SAR"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001812632020"
 
     - name: "Installation for SAP IGS integrated in SAP Kernel"
       archive: "igsexe_0-70005417.sar"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000001634982020"
 
     - name: "SAP IGS Fonts and Textures"
       archive: "igshelper_17-10010245.sar"
-      override_target_location: "/usr/sap/install/download_basket/"
+      override_target_location: "{{ target_media_location }}/download_basket"
       sapurl: "https://softwaredownloads.sap.com/file/0020000000703122018"
 
     # db export components
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_1.zip"
       archive: "S4CORE105_INST_EXPORT_1.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666752020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_10.zip"
       archive: "S4CORE105_INST_EXPORT_10.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666762020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_11.zip"
       archive: "S4CORE105_INST_EXPORT_11.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666772020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_12.zip"
       archive: "S4CORE105_INST_EXPORT_12.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666782020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_13.zip"
       archive: "S4CORE105_INST_EXPORT_13.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666802020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_14.zip"
       archive: "S4CORE105_INST_EXPORT_14.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666842020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_15.zip"
       archive: "S4CORE105_INST_EXPORT_15.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666862020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_16.zip"
       archive: "S4CORE105_INST_EXPORT_16.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666872020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_17.zip"
       archive: "S4CORE105_INST_EXPORT_17.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666882020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_18.zip"
       archive: "S4CORE105_INST_EXPORT_18.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666892020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_19.zip"
       archive: "S4CORE105_INST_EXPORT_19.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666912020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_2.zip"
       archive: "S4CORE105_INST_EXPORT_2.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666922020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_20.zip"
       archive: "S4CORE105_INST_EXPORT_20.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666932020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_21.zip"
       archive: "S4CORE105_INST_EXPORT_21.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666942020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_22.zip"
       archive: "S4CORE105_INST_EXPORT_22.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666952020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_23.zip"
       archive: "S4CORE105_INST_EXPORT_23.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666982020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_24.zip"
       archive: "S4CORE105_INST_EXPORT_24.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666992020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_3.zip"
       archive: "S4CORE105_INST_EXPORT_3.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667022020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_4.zip"
       archive: "S4CORE105_INST_EXPORT_4.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667022020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_5.zip"
       archive: "S4CORE105_INST_EXPORT_5.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667022020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_6.zip"
       archive: "S4CORE105_INST_EXPORT_6.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667032020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_7.zip"
       archive: "S4CORE105_INST_EXPORT_7.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667052020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_8.zip"
       archive: "S4CORE105_INST_EXPORT_8.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667062020"
 
     - name: "File on DVD - S4CORE105_INST_EXPORT_9.zip"
       archive: "S4CORE105_INST_EXPORT_9.zip"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001667072020"
 
     - name: "File on DVD - S4HANAOP105_ERP_LANG_DE.SAR"
       archive: "S4HANAOP105_ERP_LANG_DE.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001665632020"
 
     - name: "File on DVD - S4HANAOP105_ERP_LANG_EN.SAR"
       archive: "S4HANAOP105_ERP_LANG_EN.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001665642020"
 
     - name: "Attribute Change Package 19 for SRA004 600"
       archive: "SRA004600.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666922020"
 
     - name: "Attribute Change Package 21 for UIILM001 100"
       archive: "UIILM001100.SAR"
-      override_target_location: "/usr/sap/install/cd_exports/"
+      override_target_location: "{{ target_media_location }}/cd_exports"
       sapurl: "https://softwaredownloads.sap.com/file/0030000001666922020"
 
     # other components
-
-    - name:     SAPCAR
-      version:  7.21
-      archive:  SAPCAR_1320-80000935.EXE
-      override_target_filename: SAPCAR.EXE
 
     - name: "Attribute Change Package 16 for EA-HR 608"
       archive: "EA-HR608.SAR"
@@ -489,5 +483,5 @@ materials:
 
   templates:
 
-    - name: "S4HANA_2020_ISS_v001 ini file"
-      file: "S4HANA_2020_ISS_v001.inifile.params"
+    - name: "SAP_S4HANA_2020 ini file"
+      file: "SAP_S4HANA_2020.inifile.params"

--- a/documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom.yml
+++ b/documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom.yml
@@ -1,6 +1,6 @@
 ---
 
-name: "SAP_S4HANA_2020"
+name: "S4HANA_2020_ISS_v001"
 target: "ABAP PLATFORM 2020"
 version: "001"
 
@@ -9,8 +9,8 @@ defaults:
 
 materials:
   dependencies:
-    - name: "HANA2"
-      version: "003"
+    - name: "HANA_2_00_052_v001"
+      version: "001"
 
   media:
 
@@ -483,5 +483,5 @@ materials:
 
   templates:
 
-    - name: "SAP_S4HANA_2020 ini file"
-      file: "SAP_S4HANA_2020.inifile.params"
+    - name: "S4HANA_2020_ISS_v001 ini file"
+      file: "S4HANA_2020_ISS_v001.inifile.params"

--- a/documentation/ansible/system-design-deployment/hana/prepare-bom.md
+++ b/documentation/ansible/system-design-deployment/hana/prepare-bom.md
@@ -25,8 +25,7 @@ step|BoM Content
 [3] |version: 001
     |
 [4] |defaults:
-    |  archive_location: "https://npweeusaplib9545.file.core.windows.net/sapbits/archives/"
-    |  target_location: "/usr/sap/downloads/"
+    |  target_location: "{{ target_media_location }}/downloads/"
     |
 [5] |materials:
 [6] |  media:
@@ -69,8 +68,7 @@ step|BoM Content
 ### Create Defaults Section
 
 1. `[4]`: This section contains:
-   1. `archive_location`: The location to which you will upload the SAP build files. Also, the same location from which the files will be copied to the target server.
-   1. `target_location`: The folder on the target server, into which the files will be copied for installation.
+   1. `target_location`: The folder on the target server, into which the files will be copied for installation. Normally, this will reference `{{ target_media_location }}` as shown, but could be an unrelated path.
 
 ### Create Materials Section
 
@@ -97,7 +95,7 @@ step|BoM Content
 
 ### Override Target Destination
 
-Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This is normally set using the `defaults -> target_location` property (see [the defaults section](#red_circle-create-defaults-section)). However, you may override this on a case-by-case basis, although this is not normally necessary.
+Files downloaded or shared from the archive space will need to be extracted to the correct location on the target server. This is normally set using the `defaults -> target_location` property (see [the defaults section](#red_circle-create-defaults-section)). However, you may override this on a case-by-case basis as shown. Overrides will normally reference `{{ target_media_location }}` as shown, but could be an unrelated path.
 
 1. For each relevant entry in the BoM `media` section, add an `override_target_location:` property with the correct target folder. For example:
 
@@ -105,7 +103,7 @@ Files downloaded or shared from the archive space will need to be extracted to t
    - name:     HANA 2.0
      version:  2.00.052
      archive:  51054623.ZIP
-     override_target_location: "/usr/sap/elsewhere/"
+     override_target_location: "{{ target_media_location }}/elsewhere/"
    ```
 
 ### Override Target Filename

--- a/util/generate_bom.sh
+++ b/util/generate_bom.sh
@@ -127,9 +127,9 @@ BEGIN {
 
 END {
 
-  printf("---\n\nname: \"%s\"\ntarget: \"%s\"\nversion: \"001\"\n\ndefaults:\n", product, targetname);
-  printf("  archive_location: \"%s/\"\n  target_location: \"/usr/sap/install/downloads/\"\n\n", archive);
-  printf("materials:\n  dependencies:\n    - name: \"HANA2\"\n      version: \"003\"\n\n  media:\n");
+  printf("---\n\nname: \"%s\"\ntarget: \"%s\"\nversion: \"001\"\n", product, targetname);
+  printf("\ndefaults:\n  target_location: \"{{ target_media_location }}/downloads/\"\n");
+  printf("\nmaterials:\n  dependencies:\n    - name: \"HANA2\"\n      version: \"003\"\n\n  media:\n");
 
   while ( getline < "tempworkfile" ) {
     seq = $1;
@@ -138,16 +138,16 @@ END {
     component = $4;
     if ( component == "File on DVD" ) component = (component " - " $3)
 
-    dir = "/usr/sap/install/downloads";
+    dir = "{{ target_media_location }}";
     current = substr(seq,1,2);
     if (current != phase ) {
       phase = current;
       if ( phase == "AA" ) {
         printf("\n    # kernel components\n");
-        overridedir = "/usr/sap/install/download_basket";
+        overridedir = "{{ target_media_location }}/download_basket";
       } else if ( phase == "BB" ) {
         printf("\n    # db export components\n");
-        overridedir = "/usr/sap/install/cd_exports";
+        overridedir = "{{ target_media_location }}/cd_exports";
       } else {
         printf("\n    # other components\n");
         overridedir = "";


### PR DESCRIPTION
## Problem

Ansible code production has highlighted a few deficiencies in the BoM layout to do with variable declarations.

## Solution

- Rewrite BoM preparation docs to align with current thinking.
- Refactor BoM generation script to match new docs.
- Update example BoMs in line with above.

## Tests

- [x] Doc changes LGTM.
- [x] Script changes LGTM (match docs).
- [x] Example BoMs LGTM (match docs).

## Notes

The `archive_location` has been removed from the BoM. This variable now needs to be supplied to the role (in the inventory, in the playbook, etc).
The `target_location` has been updated to reference a new variable, `target_media_location`, to be supplied to the role (in the inventory, in the playbook, etc).